### PR TITLE
Fix:  解壓縮時 tar 無法變更檔案模式/權限 (#3)

### DIFF
--- a/update_data.sh
+++ b/update_data.sh
@@ -93,7 +93,7 @@ fi
 
 # 解壓縮檔案
 echo "開始解壓縮 release.tar.gz..."
-tar -xvf "$DOWNLOAD_DIR/release.tar.gz" -C "$DOWNLOAD_DIR"
+tar -xvf "$DOWNLOAD_DIR/release.tar.gz" -C "$DOWNLOAD_DIR" --no-same-permissions || echo "解壓縮過程中出現權限警告，但將繼續執行..."
 
 # 在安裝模式下，不需要特別刪除壓縮檔，因為整個臨時目錄會被清理
 # 在普通模式下，保留壓縮檔，讓用戶自行決定是否刪除

--- a/update_data.sh
+++ b/update_data.sh
@@ -93,7 +93,12 @@ fi
 
 # 解壓縮檔案
 echo "開始解壓縮 release.tar.gz..."
-tar -xvf "$DOWNLOAD_DIR/release.tar.gz" -C "$DOWNLOAD_DIR" --no-same-permissions || echo "解壓縮過程中出現權限警告，但將繼續執行..."
+tar --no-same-permissions -xvf "$DOWNLOAD_DIR/release.tar.gz" -C "$DOWNLOAD_DIR"
+
+if [ $? -ne 0 ]; then
+  echo "解壓縮檔案失敗"
+  exit 1
+fi
 
 # 在安裝模式下，不需要特別刪除壓縮檔，因為整個臨時目錄會被清理
 # 在普通模式下，保留壓縮檔，讓用戶自行決定是否刪除


### PR DESCRIPTION
此 Pull Request 旨在修復在執行腳本進行檔案解壓縮 (untar) 時，`tar` 指令因無法正確設定解壓縮出來的檔案模式或權限而導致失敗的問題。

**問題背景**

如 Issue #3 所述，在某些環境下（例如在 QNAP Docker 中透過 `entrypoint` 執行自動更新腳本），`tar` 在解壓縮資料檔案時，會嘗試恢復歸檔中記錄的原始檔案權限或模式。然而，由於執行環境的檔案系統可能存在限制，`tar` 在嘗試使用 `chmod` 等系統呼叫變更檔案模式時會失敗，並出現類似以下的錯誤：

```
tar: ./geodata: Cannot change mode to rwxr-xr-x: Bad address
tar: ...: Cannot change mode to ...: Bad address
tar: Exiting with failure status due to previous errors
```

這個問題會導致自動更新腳本中斷，進而導致 Immich 容器不斷重啟。

**解決方案**

透過在 `tar` 指令中加入 `--no-same-permissions`，可以指示 `tar` 在解壓縮時忽略歸檔內部的權限和擁有者設定，而是使用當前環境的預設權限和擁有者來建立檔案。這能有效繞過因檔案系統限制導致的權限設定失敗問題。

**致謝與貢獻**

**特別感謝 @shiuh67** 在先前的 Issue #3 和 Pull Request #6 中，首先發現該問題，並提出解決權限衝突的有效解決方案。

此 PR 基於 @shiuh67 的解決方案，並包含額外錯誤處理及驗證，以提升腳本的整體穩定性。

**關閉 Issue**

Closes #3
