### PR TITLE
refactor: 統一 country_code 過濾邏輯至 main.py

### DIFF
--- a/core/prepare_geoname.py
+++ b/core/prepare_geoname.py
@@ -1,7 +1,6 @@
 import os
 import requests
 import zipfile
-from core.geodata import get_handler
 
 from core.utils import logger, rebuild_folder
 
@@ -59,18 +58,7 @@ def download(countries=["TW"], update=False):
     else:
         logger.info(f"{TXT_FILE} 已存在，跳過下載。")
 
-    # 檢查哪些國家有註冊的 Handler，跳過這些國家的下載
     for country in countries:
-        # 檢查是否有對應的 Handler
-        try:
-            get_handler(country)
-            logger.info(
-                f"跳過 {country} 的資料下載（使用 {country}GeoDataHandler 產生精準資料）"
-            )
-            continue  # 有 Handler，跳過下載
-        except ValueError:
-            pass
-
         country_zip = os.path.join(EXTRA_DATA_DIR, f"{country}.zip")
         country_txt = os.path.join(EXTRA_DATA_DIR, f"{country}.txt")
         if not os.path.exists(country_txt):


### PR DESCRIPTION
## 摘要
集中所有 `--country-code` 參數的過濾邏輯，避免重複代碼並提升可維護性。

## 變更內容
- ✅ 新增 `filter_countries_without_handler()` 函數統一處理過濾邏輯
- ✅ 在 `main()` 中自動過濾所有子命令的 `country_code` 參數
- ✅ 移除 `cmd_enhance()` 和 `cmd_release()` 中的重複過濾代碼
- ✅ 移除 `core/prepare_geoname.py` 中的重複過濾代碼
- ✅ 將所有 import 移至檔案頂部，符合 Python 標準
- ✅ 添加明確的類型註解 (`list[str] -> list[str]`)

## 優勢
- **DRY 原則**：過濾邏輯只在一處維護
- **自動化**：所有使用 `--country-code` 的命令自動過濾
- **使用者體驗**：為被過濾的國家顯示警告訊息
- **程式碼簡化**：移除了三處重複邏輯（淨減少 2 行代碼）

## 測試計畫
- [x] ruff format 通過
- [x] ruff check 通過
- [x] mypy 類型檢查通過（無新增錯誤）
- [x] 確認所有 import 位於檔案頂部
- [x] 確認類型註解正確

## 影響範圍
- `main.py`：新增過濾函數，簡化命令函數
- `core/prepare_geoname.py`：移除重複過濾邏輯

## 相關 Issue
解決重複代碼問題，提升代碼可維護性。