### PR TITLE
fix(workflow): 重新命名 nightly 分支為 nightly-build 解決 refspec 衝突

### DIFF
--- a/.github/workflows/auto-update.yaml
+++ b/.github/workflows/auto-update.yaml
@@ -22,8 +22,8 @@ jobs:
         with:
           fetch-depth: 0
           ref: main
-      - name: Create nightly branch
-        run: git checkout -B nightly
+      - name: Create nightly-build branch
+        run: git checkout -B nightly-build
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -41,7 +41,7 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v5
         id: auto-commit
         with:
-          branch: nightly
+          branch: nightly-build
           commit_message: Auto update reverse geocoding data on ${{ env.TODAY }}
           file_pattern: meta_data/*
           push_options: '--force'
@@ -62,7 +62,7 @@ jobs:
             如果遇到 Immich 沒有更新數據，請手動修改 geodata-date.txt 文件，將其內容中的時間修改為更新的時間（比如當前時間）。
           draft: false
           generateReleaseNotes: false
-          commit: nightly
+          commit: nightly-build
           tag: nightly
           makeLatest: false
           prerelease: true
@@ -71,11 +71,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          existing=$(gh pr list --head nightly --state open --json number --jq 'length')
+          existing=$(gh pr list --head nightly-build --state open --json number --jq 'length')
           if [ "$existing" -eq 0 ]; then
             gh pr create \
               --base main \
-              --head nightly \
+              --head nightly-build \
               --title "chore(geodata): 自動更新 ${{ env.TODAY }}" \
               --body "這是 nightly 自動更新產生的 geodata 變更，請審核後合併。"
           else

--- a/.github/workflows/sync-nightly.yaml
+++ b/.github/workflows/sync-nightly.yaml
@@ -12,18 +12,18 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout nightly
+      - name: Checkout nightly-build
         uses: actions/checkout@v4
         with:
-          ref: nightly
+          ref: nightly-build
           fetch-depth: 0
       - name: Configure git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-      - name: Reset nightly to main
+      - name: Reset nightly-build to main
         run: |
           git fetch origin main
           git reset --hard origin/main
-      - name: Force push nightly
-        run: git push --force origin HEAD:refs/heads/nightly
+      - name: Force push nightly-build
+        run: git push --force origin HEAD:refs/heads/nightly-build


### PR DESCRIPTION
## 摘要

修復 Auto Update workflow 連續失敗的 `dst refspec nightly matches more than one` 錯誤。問題根因為遠端同時存在同名的 `refs/heads/nightly` 與 `refs/tags/nightly`，導致 `git-auto-commit-action` 推送時無法解析 namespace。

## 變更內容

採用分離 namespace 策略：
- **分支**：`nightly` → `nightly-build`（保留 nightly 概念連結，避免與 tag 同名）
- **Tag**：維持 `nightly`（對外發布識別不變）

涉及檔案：
- `.github/workflows/auto-update.yaml`：6 處分支引用更新
- `.github/workflows/sync-nightly.yaml`：2 處分支引用更新

## 設計考量

維持原專案 \"四個單例\"（branch / tag / pre-release / PR 各自唯一）的設計約束。改名僅影響分支識別字，不改動既有 force-push 與 release 重建邏輯，亦不引入新的步驟相依。

## 配套動作（合併後執行）

- 一次性遠端清理：刪除舊的 `nightly` 分支與殘留的 `nightly` tag。
- 手動觸發 `Auto Update` 驗證新流程。

## 測試計畫

- [ ] 合併後手動觸發 `auto-update.yaml`，確認 push 步驟通過
- [ ] 驗證遠端建立 `nightly-build` 分支
- [ ] 驗證 `nightly` tag 與 pre-release 重建成功
- [ ] 驗證 PR 以 `nightly-build` 為 head 自動開啟
- [ ] 下週五排程觸發後再次確認穩定性