### PR TITLE
fix(wikidata): 恢復 KR extract 翻譯快取流程

### DIFF
--- a/.codex/agents/code-simplifier.toml
+++ b/.codex/agents/code-simplifier.toml
@@ -1,0 +1,53 @@
+name = "code-simplifier"
+description = "Simplifies and refines code for clarity, consistency, and maintainability while preserving all functionality. Focuses on recently modified code unless instructed otherwise."
+model = "gpt-5.5"
+model_reasoning_effort = "high"
+sandbox_mode = "workspace-write"
+developer_instructions = """
+You are an expert code simplification specialist focused on enhancing code clarity, consistency, and maintainability while preserving exact functionality. Your expertise lies in applying project-specific best practices to simplify and improve code without altering its behavior. You prioritize readable, explicit code over overly compact solutions. This is a balance that you have mastered as a result your years as an expert software engineer.
+
+You will analyze recently modified code and apply refinements that:
+
+1. Preserve Functionality: Never change what the code does - only how it does it. All original features, outputs, and behaviors must remain intact.
+
+2. Apply Project Standards: Follow the established coding standards from CLAUDE.md including:
+
+   - Use ES modules with proper import sorting and extensions
+   - Prefer `function` keyword over arrow functions
+   - Use explicit return type annotations for top-level functions
+   - Follow proper React component patterns with explicit Props types
+   - Use proper error handling patterns (avoid try/catch when possible)
+   - Maintain consistent naming conventions
+
+3. Enhance Clarity: Simplify code structure by:
+
+   - Reducing unnecessary complexity and nesting
+   - Eliminating redundant code and abstractions
+   - Improving readability through clear variable and function names
+   - Consolidating related logic
+   - Removing unnecessary comments that describe obvious code
+   - IMPORTANT: Avoid nested ternary operators - prefer switch statements or if/else chains for multiple conditions
+   - Choose clarity over brevity - explicit code is often better than overly compact code
+
+4. Maintain Balance: Avoid over-simplification that could:
+
+   - Reduce code clarity or maintainability
+   - Create overly clever solutions that are hard to understand
+   - Combine too many concerns into single functions or components
+   - Remove helpful abstractions that improve code organization
+   - Prioritize "fewer lines" over readability (e.g., nested ternaries, dense one-liners)
+   - Make the code harder to debug or extend
+
+5. Focus Scope: Only refine code that has been recently modified or touched in the current session, unless explicitly instructed to review a broader scope.
+
+Your refinement process:
+
+1. Identify the recently modified code sections
+2. Analyze for opportunities to improve elegance and consistency
+3. Apply project-specific best practices and coding standards
+4. Ensure all functionality remains unchanged
+5. Verify the refined code is simpler and more maintainable
+6. Document only significant changes that affect understanding
+
+You operate autonomously and proactively, refining code immediately after it's written or modified without requiring explicit requests. Your goal is to ensure all code meets the highest standards of elegance and maintainability while preserving its complete functionality.
+"""

--- a/.codex/agents/refactoring-specialist.toml
+++ b/.codex/agents/refactoring-specialist.toml
@@ -1,0 +1,41 @@
+name = "refactoring-specialist"
+description = "Use when a task needs a low-risk structural refactor that preserves behavior while improving readability, modularity, or maintainability."
+model = "gpt-5.5"
+model_reasoning_effort = "high"
+sandbox_mode = "workspace-write"
+developer_instructions = """
+Own behavior-preserving refactoring work as developer productivity and workflow reliability engineering, not checklist execution.
+
+Prioritize the smallest practical change or recommendation that reduces friction, preserves safety, and improves day-to-day delivery speed.
+
+Working mode:
+1. Map the workflow boundary and identify the concrete pain/failure point.
+2. Distinguish evidence-backed root causes from symptoms.
+3. Implement or recommend the smallest coherent intervention.
+4. Validate one normal path, one failure path, and one integration edge.
+
+Focus on:
+- scope control to isolate structural change from feature change
+- seam extraction and modular boundary improvements with minimal churn
+- reduction of complexity, duplication, and hidden coupling
+- test safety net quality around refactored code paths
+- API/interface stability for downstream callers
+- incremental commit strategy enabling safe review and rollback
+- preservation of runtime behavior and non-functional expectations
+
+Quality checks:
+- verify refactor diff keeps behavior equivalent on critical paths
+- confirm structural improvements are measurable and localized
+- check tests cover key invariants before and after refactor
+- ensure compatibility risks are identified where signatures or contracts shift
+- call out residual technical debt intentionally deferred
+
+Return:
+- exact workflow/tool boundary analyzed or changed
+- primary friction/failure source and supporting evidence
+- smallest safe change/recommendation and key tradeoffs
+- validations performed and remaining environment-level checks
+- residual risk and prioritized follow-up actions
+
+Do not mix unrelated feature work into structural refactor changes unless explicitly requested by the parent agent.
+"""

--- a/docs/en/south-korea-admin-processing.md
+++ b/docs/en/south-korea-admin-processing.md
@@ -120,14 +120,17 @@ Use a **built-in table** with Taiwanese short names (not the canonical Wikidata 
 
 ### Rust Wikidata Translation Source and Cache
 
-The Rust production handler reads translations from the local
-`geoname_data/KR_wikidata_cache.json` file or an explicitly supplied Wikidata
-stub/cache, then applies the built-in Admin 1 and Sejong mappings. Automated
-validation does not call the live Wikidata service, keeping release gates
-independent from API quota, upstream data drift, and network availability.
+The Rust production handler uses the shared Wikidata translation cache pipeline
+to read and update the local `geoname_data/KR_wikidata_cache.json` file. If the
+cache is missing or incomplete, production extract queries Wikidata, fills the
+context-aware cache, then applies the built-in Admin 1 and Sejong mappings.
+Automated fixture validation still uses the supplied `KR_wikidata_stub.json`
+without calling the live Wikidata service, keeping release gates independent
+from API quota, upstream data drift, and network availability.
 
-When South Korea translations need updates, refresh the cache/stub first, then
-rerun extract and release parity validation with the real KR GeoJSON source.
+When South Korea translations need updates, rerun production extract with the
+real KR GeoJSON source to update the cache. Fixture and parity validation should
+continue using the matching stub/cache when deterministic output is required.
 
 **Fallback order**:
 

--- a/docs/zh-tw/south-korea-admin-processing.md
+++ b/docs/zh-tw/south-korea-admin-processing.md
@@ -121,12 +121,14 @@
 
 ### Rust Wikidata 翻譯來源與快取
 
-Rust production handler 會從本地 `geoname_data/KR_wikidata_cache.json` 或指定的
-Wikidata stub/cache 讀取翻譯結果，再套用內建 Admin 1 與世宗對照表。自動化驗證不呼叫
-即時 Wikidata 網路服務，避免 release gate 受到 API quota、上游資料漂移或網路狀態影響。
+Rust production handler 會使用通用 Wikidata translation cache pipeline 讀取並更新本地
+`geoname_data/KR_wikidata_cache.json`。若 cache 不存在或缺少翻譯項目，production
+extract 會查詢 Wikidata、補齊 context-aware cache，再套用內建 Admin 1 與世宗對照表。
+自動化 fixture 驗證仍使用指定的 `KR_wikidata_stub.json`，不呼叫即時 Wikidata 網路服務，
+避免 release gate 受到 API quota、上游資料漂移或網路狀態影響。
 
-若需要更新南韓翻譯來源，應先更新 cache/stub，再用真實 KR GeoJSON 重新執行 extract 與
-release parity 驗證。
+若需要更新南韓翻譯來源，使用真實 KR GeoJSON 重新執行 production extract 即可更新
+cache；fixture 或 parity 驗證若需要固定輸出，仍應使用對應的 stub/cache。
 
 **回退策略**：翻譯時依序嘗試以下語言來源
 

--- a/rust/src/pipeline/extract.rs
+++ b/rust/src/pipeline/extract.rs
@@ -10,6 +10,7 @@ use std::time::Instant;
 
 mod geometry;
 mod handlers;
+mod korea_wikidata;
 mod sources;
 mod types;
 
@@ -346,11 +347,11 @@ fn read_geospatial_rows_from_path_profiled(
         fs::read_to_string(source_path)
             .map_err(|error| format!("無法讀取 GeoJSON {}：{error}", source_path.display()))
     })?;
-    let context = profile.time("load_context", || {
-        country.load_context(source_path, korea_stub)
-    })?;
     let mut features = profile.time("parse_geojson", || {
         read_geojson_features_from_content(country, &content, source_path)
+    })?;
+    let context = profile.time("load_context", || {
+        country.load_context(source_path, korea_stub, &features)
     })?;
     let source_crs = features.first().and_then(|feature| feature.crs.clone());
     profile.time("centroid", || {
@@ -376,10 +377,10 @@ fn read_shapefile_rows_from_path_profiled(
     korea_stub: Option<&Path>,
     profile: &mut ExtractProfile,
 ) -> Result<Vec<ExtractRow>, String> {
-    let context = profile.time("load_context", || {
-        country.load_context(source_path, korea_stub)
-    })?;
     let mut features = profile.time("read_shapefile", || read_shapefile(country, source_path))?;
+    let context = profile.time("load_context", || {
+        country.load_context(source_path, korea_stub, &features)
+    })?;
     let source_crs = features.first().and_then(|feature| feature.crs.clone());
     profile.time("centroid", || {
         apply_country_centroids(country, &mut features, source_crs.as_deref())

--- a/rust/src/pipeline/extract/handlers.rs
+++ b/rust/src/pipeline/extract/handlers.rs
@@ -273,7 +273,8 @@ fn korea_admin2(sidonm: &str, sggnm: &str, translations: &KoreaTranslations) -> 
     }
     translations
         .admin2_by_parent
-        .get(&(sidonm.to_string(), sggnm.to_string()))
+        .get(sidonm)
+        .and_then(|by_name| by_name.get(sggnm))
         .or_else(|| translations.fallback_by_name.get(sggnm))
         .cloned()
         .unwrap_or_else(|| sggnm.to_string())
@@ -368,7 +369,9 @@ fn read_korea_stub(path: &Path) -> Result<KoreaTranslations, String> {
             if let (Some(parent), Some(name)) = (parts.next(), parts.next()) {
                 translations
                     .admin2_by_parent
-                    .insert((parent.to_string(), name.to_string()), translated.clone());
+                    .entry(parent.to_string())
+                    .or_default()
+                    .insert(name.to_string(), translated.clone());
                 translations
                     .fallback_by_name
                     .insert(name.to_string(), translated);

--- a/rust/src/pipeline/extract/handlers.rs
+++ b/rust/src/pipeline/extract/handlers.rs
@@ -4,9 +4,10 @@ use std::path::Path;
 
 use serde_json::Value;
 
+use super::korea_wikidata::build_korea_wikidata_cache;
 use super::types::{
     Country, ExtractContext, ExtractRow, Feature, FeatureGeometry, KoreaTranslations,
-    korea_translation_source,
+    korea_stub_source, korea_translation_cache_path,
 };
 
 impl Country {
@@ -14,6 +15,7 @@ impl Country {
         self,
         source_path: &Path,
         korea_stub: Option<&Path>,
+        features: &[Feature],
     ) -> Result<ExtractContext, String> {
         match self {
             Self::Taiwan | Self::Japan => Ok(ExtractContext::default()),
@@ -21,14 +23,13 @@ impl Country {
                 let stub = korea_stub
                     .filter(|path| path.exists())
                     .map(Path::to_path_buf)
-                    .or_else(|| korea_translation_source(source_path))
-                    .ok_or_else(|| {
-                        "KR extract 需要 Wikidata stub/cache，避免 production gate 呼叫即時網路"
-                            .to_string()
-                    })?;
-                Ok(ExtractContext {
-                    korea_translations: read_korea_stub(&stub)?,
-                })
+                    .or_else(|| korea_stub_source(source_path));
+                let korea_translations = if let Some(stub) = stub {
+                    read_korea_stub(&stub)?
+                } else {
+                    build_korea_wikidata_cache(features, &korea_translation_cache_path())?
+                };
+                Ok(ExtractContext { korea_translations })
             }
         }
     }
@@ -178,17 +179,44 @@ fn korea_feature_row(
     translations: &KoreaTranslations,
 ) -> Result<ExtractRow, String> {
     let (longitude, latitude) = point_geometry(&feature.geometry)?;
-    let sidonm = attribute(feature, "sidonm");
+    let components = korea_admin_components(feature);
+
+    let mut admin2 = korea_admin2(&components.sidonm, &components.sggnm, translations);
+    if components.sidonm == "광주광역시" {
+        admin2 = strip_trailing_parenthetical(&admin2);
+    }
+
+    Ok(ExtractRow::from_point(
+        latitude,
+        longitude,
+        "南韓",
+        korea_admin1(&components.sidonm, translations),
+        admin2,
+        components.admin3,
+        components.admin4,
+    ))
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct KoreaAdminComponents {
+    pub(super) sidonm: String,
+    pub(super) sggnm: String,
+    pub(super) admin3: String,
+    pub(super) admin4: String,
+}
+
+pub(super) fn korea_admin_components(feature: &Feature) -> KoreaAdminComponents {
+    let sidonm = attribute(feature, "sidonm").to_string();
     let mut sggnm = attribute(feature, "sggnm").to_string();
     let adm_nm = attribute(feature, "adm_nm");
     let mut admin3 = adm_nm
-        .replace(sidonm, "")
+        .replace(&sidonm, "")
         .replace(&sggnm, "")
         .trim()
         .to_string();
     let mut admin4 = String::new();
 
-    if is_sejong_admin2_normalization_target(sidonm, &sggnm) {
+    if is_sejong_admin2_normalization_target(&sidonm, &sggnm) {
         sggnm = admin3;
         admin3 = String::new();
     }
@@ -199,20 +227,12 @@ fn korea_feature_row(
         admin3 = district;
     }
 
-    let mut admin2 = korea_admin2(sidonm, &sggnm, translations);
-    if sidonm == "광주광역시" {
-        admin2 = strip_trailing_parenthetical(&admin2);
-    }
-
-    Ok(ExtractRow::from_point(
-        latitude,
-        longitude,
-        "南韓",
-        korea_admin1(sidonm, translations),
-        admin2,
+    KoreaAdminComponents {
+        sidonm,
+        sggnm,
         admin3,
         admin4,
-    ))
+    }
 }
 
 fn korea_admin1(name: &str, translations: &KoreaTranslations) -> String {

--- a/rust/src/pipeline/extract/korea_wikidata.rs
+++ b/rust/src/pipeline/extract/korea_wikidata.rs
@@ -34,8 +34,7 @@ pub(super) fn build_korea_wikidata_cache(
         .iter()
         .map(korea_admin_components)
         .collect::<Vec<_>>();
-    let admin1_dataset =
-        builder.build_admin1_names(components.iter().map(|row| row.sidonm.clone()))?;
+    let admin1_dataset = builder.build_admin1_names(components.iter().map(|row| &row.sidonm))?;
     let options = WikidataClientOptions::new("ko", "zh-tw");
     let mut translator = WikidataTranslator::new(options, Some(cache_path.to_path_buf()), true)?;
     let admin1_results = translator.batch_translate(
@@ -49,7 +48,7 @@ pub(super) fn build_korea_wikidata_cache(
         components
             .iter()
             .filter(|row| row.sidonm != "세종특별자치시")
-            .map(|row| (row.sidonm.clone(), row.sggnm.clone())),
+            .map(|row| (&row.sidonm, &row.sggnm)),
         true,
     )?;
     let parent_qids = admin2_parent_qids(&admin1_dataset, &admin1_results, &admin2_dataset);
@@ -76,14 +75,23 @@ fn admin2_parent_qids(
     admin1_results: &HashMap<String, TranslationResult>,
     admin2_dataset: &TranslationDataset,
 ) -> HashMap<String, String> {
+    let admin1_qids = admin1_dataset
+        .items()
+        .iter()
+        .filter_map(|item| {
+            admin1_results
+                .get(&item.id)
+                .and_then(|result| result.qid.clone())
+                .map(|qid| (item.original_name.as_str(), qid))
+        })
+        .collect::<HashMap<_, _>>();
     let mut parent_qids = HashMap::new();
     for item in admin2_dataset.items() {
         let parent_name = item.parent_chain.last().cloned().unwrap_or_default();
-        let Some(parent_qid) = admin1_result_qid(admin1_dataset, admin1_results, &parent_name)
-        else {
+        let Some(parent_qid) = admin1_qids.get(parent_name.as_str()) else {
             continue;
         };
-        parent_qids.insert(item.id.clone(), parent_qid);
+        parent_qids.insert(item.id.clone(), parent_qid.clone());
     }
     parent_qids
 }
@@ -117,19 +125,6 @@ fn korea_translations_from_results(
     translations
 }
 
-fn admin1_result_qid(
-    dataset: &TranslationDataset,
-    results: &HashMap<String, TranslationResult>,
-    parent_name: &str,
-) -> Option<String> {
-    dataset
-        .items()
-        .iter()
-        .find(|item| item.original_name == parent_name)
-        .and_then(|item| results.get(&item.id))
-        .and_then(|result| result.qid.clone())
-}
-
 fn korea_result_text(item: &TranslationItem, result: &TranslationResult) -> String {
     if result.translated.is_empty() {
         item.original_name.clone()
@@ -143,6 +138,6 @@ fn korea_candidate_allowed(metadata: &WikidataCandidateMetadata) -> bool {
         let lower = label.to_ascii_lowercase();
         !EXCLUDED_KEYWORDS
             .iter()
-            .any(|keyword| lower.contains(&keyword.to_ascii_lowercase()))
+            .any(|keyword| lower.contains(keyword))
     })
 }

--- a/rust/src/pipeline/extract/korea_wikidata.rs
+++ b/rust/src/pipeline/extract/korea_wikidata.rs
@@ -87,8 +87,10 @@ fn admin2_parent_qids(
         .collect::<HashMap<_, _>>();
     let mut parent_qids = HashMap::new();
     for item in admin2_dataset.items() {
-        let parent_name = item.parent_chain.last().cloned().unwrap_or_default();
-        let Some(parent_qid) = admin1_qids.get(parent_name.as_str()) else {
+        let Some(parent_name) = item.parent_chain.get(1).map(String::as_str) else {
+            continue;
+        };
+        let Some(parent_qid) = admin1_qids.get(parent_name) else {
             continue;
         };
         parent_qids.insert(item.id.clone(), parent_qid.clone());
@@ -116,7 +118,9 @@ fn korea_translations_from_results(
             let parent = item.parent_chain.last().cloned().unwrap_or_default();
             translations
                 .admin2_by_parent
-                .insert((parent, item.original_name.clone()), translated.clone());
+                .entry(parent)
+                .or_default()
+                .insert(item.original_name.clone(), translated.clone());
             translations
                 .fallback_by_name
                 .insert(item.original_name.clone(), translated);
@@ -133,7 +137,7 @@ fn korea_result_text(item: &TranslationItem, result: &TranslationResult) -> Stri
     }
 }
 
-fn korea_candidate_allowed(metadata: &WikidataCandidateMetadata) -> bool {
+fn korea_candidate_allowed(metadata: &WikidataCandidateMetadata<'_>) -> bool {
     metadata.labels.values().all(|label| {
         let lower = label.to_ascii_lowercase();
         !EXCLUDED_KEYWORDS

--- a/rust/src/pipeline/extract/korea_wikidata.rs
+++ b/rust/src/pipeline/extract/korea_wikidata.rs
@@ -1,0 +1,148 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+use crate::wikidata::{
+    BatchTranslateOptions, TranslationDataset, TranslationDatasetBuilder, TranslationItem,
+    TranslationResult, WikidataCandidateMetadata, WikidataClientOptions, WikidataTranslator,
+};
+
+use super::handlers::korea_admin_components;
+use super::types::{Feature, KoreaTranslations};
+
+const EXCLUDED_KEYWORDS: &[&str] = &[
+    "의회",
+    "議會",
+    "council",
+    "assembly",
+    "委員會",
+    "legislature",
+    "廳",
+    "government",
+    "교육청",
+    "도청",
+    "군청",
+    "구청",
+    "시청",
+];
+
+pub(super) fn build_korea_wikidata_cache(
+    features: &[Feature],
+    cache_path: &Path,
+) -> Result<KoreaTranslations, String> {
+    let builder = TranslationDatasetBuilder::new("KR", "ko", "zh-tw")?;
+    let components = features
+        .iter()
+        .map(korea_admin_components)
+        .collect::<Vec<_>>();
+    let admin1_dataset =
+        builder.build_admin1_names(components.iter().map(|row| row.sidonm.clone()))?;
+    let options = WikidataClientOptions::new("ko", "zh-tw");
+    let mut translator = WikidataTranslator::new(options, Some(cache_path.to_path_buf()), true)?;
+    let admin1_results = translator.batch_translate(
+        &admin1_dataset,
+        BatchTranslateOptions {
+            batch_size: 32,
+            ..BatchTranslateOptions::default()
+        },
+    )?;
+    let admin2_dataset = builder.build_admin2_pairs(
+        components
+            .iter()
+            .filter(|row| row.sidonm != "세종특별자치시")
+            .map(|row| (row.sidonm.clone(), row.sggnm.clone())),
+        true,
+    )?;
+    let parent_qids = admin2_parent_qids(&admin1_dataset, &admin1_results, &admin2_dataset);
+    let candidate_filter =
+        |_: &str, metadata: &WikidataCandidateMetadata| korea_candidate_allowed(metadata);
+    let admin2_results = translator.batch_translate(
+        &admin2_dataset,
+        BatchTranslateOptions {
+            batch_size: 32,
+            parent_qids,
+            candidate_filter: Some(&candidate_filter),
+        },
+    )?;
+    Ok(korea_translations_from_results(
+        &admin1_dataset,
+        &admin1_results,
+        &admin2_dataset,
+        &admin2_results,
+    ))
+}
+
+fn admin2_parent_qids(
+    admin1_dataset: &TranslationDataset,
+    admin1_results: &HashMap<String, TranslationResult>,
+    admin2_dataset: &TranslationDataset,
+) -> HashMap<String, String> {
+    let mut parent_qids = HashMap::new();
+    for item in admin2_dataset.items() {
+        let parent_name = item.parent_chain.last().cloned().unwrap_or_default();
+        let Some(parent_qid) = admin1_result_qid(admin1_dataset, admin1_results, &parent_name)
+        else {
+            continue;
+        };
+        parent_qids.insert(item.id.clone(), parent_qid);
+    }
+    parent_qids
+}
+
+fn korea_translations_from_results(
+    admin1_dataset: &TranslationDataset,
+    admin1_results: &HashMap<String, TranslationResult>,
+    admin2_dataset: &TranslationDataset,
+    admin2_results: &HashMap<String, TranslationResult>,
+) -> KoreaTranslations {
+    let mut translations = KoreaTranslations::default();
+    for item in admin1_dataset.items() {
+        if let Some(result) = admin1_results.get(&item.id) {
+            translations
+                .admin1_by_name
+                .insert(item.original_name.clone(), korea_result_text(item, result));
+        }
+    }
+    for item in admin2_dataset.items() {
+        if let Some(result) = admin2_results.get(&item.id) {
+            let translated = korea_result_text(item, result);
+            let parent = item.parent_chain.last().cloned().unwrap_or_default();
+            translations
+                .admin2_by_parent
+                .insert((parent, item.original_name.clone()), translated.clone());
+            translations
+                .fallback_by_name
+                .insert(item.original_name.clone(), translated);
+        }
+    }
+    translations
+}
+
+fn admin1_result_qid(
+    dataset: &TranslationDataset,
+    results: &HashMap<String, TranslationResult>,
+    parent_name: &str,
+) -> Option<String> {
+    dataset
+        .items()
+        .iter()
+        .find(|item| item.original_name == parent_name)
+        .and_then(|item| results.get(&item.id))
+        .and_then(|result| result.qid.clone())
+}
+
+fn korea_result_text(item: &TranslationItem, result: &TranslationResult) -> String {
+    if result.translated.is_empty() {
+        item.original_name.clone()
+    } else {
+        result.translated.clone()
+    }
+}
+
+fn korea_candidate_allowed(metadata: &WikidataCandidateMetadata) -> bool {
+    metadata.labels.values().all(|label| {
+        let lower = label.to_ascii_lowercase();
+        !EXCLUDED_KEYWORDS
+            .iter()
+            .any(|keyword| lower.contains(&keyword.to_ascii_lowercase()))
+    })
+}

--- a/rust/src/pipeline/extract/types.rs
+++ b/rust/src/pipeline/extract/types.rs
@@ -175,7 +175,7 @@ impl FeatureAttributes {
 #[derive(Clone, Debug, Default)]
 pub(super) struct KoreaTranslations {
     pub(super) admin1_by_name: HashMap<String, String>,
-    pub(super) admin2_by_parent: HashMap<(String, String), String>,
+    pub(super) admin2_by_parent: HashMap<String, HashMap<String, String>>,
     pub(super) fallback_by_name: HashMap<String, String>,
 }
 

--- a/rust/src/pipeline/extract/types.rs
+++ b/rust/src/pipeline/extract/types.rs
@@ -239,13 +239,13 @@ impl Country {
     }
 }
 
-pub(super) fn korea_translation_source(source_path: &std::path::Path) -> Option<PathBuf> {
+pub(super) fn korea_stub_source(source_path: &std::path::Path) -> Option<PathBuf> {
     source_path
         .parent()
         .map(|parent| parent.join("KR_wikidata_stub.json"))
         .filter(|path| path.exists())
-        .or_else(|| {
-            let cache = std::path::Path::new("geoname_data").join("KR_wikidata_cache.json");
-            cache.exists().then_some(cache)
-        })
+}
+
+pub(super) fn korea_translation_cache_path() -> PathBuf {
+    std::path::Path::new("geoname_data").join("KR_wikidata_cache.json")
 }

--- a/rust/src/wikidata/cache.rs
+++ b/rust/src/wikidata/cache.rs
@@ -1,0 +1,353 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use chrono::Utc;
+use serde_json::{Map, Value, json};
+
+use super::types::{TranslationItem, TranslationResult};
+
+const VERSION: &str = "1.0";
+
+#[derive(Debug, Clone)]
+pub struct TranslationCacheStore {
+    pub cache_path: Option<PathBuf>,
+    metadata: Map<String, Value>,
+    translations: Map<String, Value>,
+    search: Map<String, Value>,
+    labels: Map<String, Value>,
+    p131: Map<String, Value>,
+    instance_of: Map<String, Value>,
+    indexes_by_name: Map<String, Value>,
+    dirty: usize,
+    last_flush: Instant,
+}
+
+impl TranslationCacheStore {
+    pub fn load(
+        source_lang: impl Into<String>,
+        target_lang: impl Into<String>,
+        cache_path: Option<PathBuf>,
+    ) -> Result<Self, String> {
+        let source_lang = source_lang.into();
+        let target_lang = target_lang.into();
+        let Some(path) = cache_path.as_deref() else {
+            return Ok(Self::empty(source_lang, target_lang, None));
+        };
+        if !path.exists() {
+            return Ok(Self::empty(
+                source_lang,
+                target_lang,
+                Some(path.to_path_buf()),
+            ));
+        }
+
+        let content = fs::read_to_string(path)
+            .map_err(|error| format!("無法讀取 Wikidata cache {}：{error}", path.display()))?;
+        let root: Value = serde_json::from_str(&content)
+            .map_err(|error| format!("Wikidata cache JSON 解析失敗 {}：{error}", path.display()))?;
+        if let Some(version) = root
+            .get("metadata")
+            .and_then(Value::as_object)
+            .and_then(|metadata| metadata.get("version"))
+            .and_then(Value::as_str)
+            .filter(|version| *version != VERSION)
+        {
+            let backup = path.with_extension(format!("{}.bak", version));
+            fs::copy(path, &backup).map_err(|error| {
+                format!(
+                    "Wikidata cache schema 不相容且備份失敗 {}：{error}",
+                    backup.display()
+                )
+            })?;
+            return Ok(Self::empty(
+                source_lang,
+                target_lang,
+                Some(path.to_path_buf()),
+            ));
+        }
+
+        let mut store = Self::empty(source_lang, target_lang, Some(path.to_path_buf()));
+        store.metadata = object_at(&root, &["metadata"]).unwrap_or_else(|| store.metadata.clone());
+        store.translations = object_at(&root, &["translations"]).unwrap_or_default();
+        store.search = object_at(&root, &["cache", "search"]).unwrap_or_default();
+        store.labels = object_at(&root, &["cache", "labels"]).unwrap_or_default();
+        store.p131 = object_at(&root, &["cache", "p131"]).unwrap_or_default();
+        store.instance_of = object_at(&root, &["cache", "instance_of"]).unwrap_or_default();
+        store.indexes_by_name = object_at(&root, &["indexes", "by_name"]).unwrap_or_default();
+        Ok(store)
+    }
+
+    pub fn get_translation(&self, item: &TranslationItem) -> Option<TranslationResult> {
+        let entry = self.translations.get(&item.id)?.as_object()?;
+        let translated = entry.get("translated")?.as_str()?.to_string();
+        Some(TranslationResult {
+            translated,
+            qid: entry
+                .get("qid")
+                .and_then(Value::as_str)
+                .map(ToString::to_string),
+            source: string_field(entry, "source", "cache"),
+            used_lang: string_field(entry, "used_lang", "unknown"),
+            parent_verified: entry
+                .get("parent_verified")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+        })
+    }
+
+    pub fn set_translation(
+        &mut self,
+        item: &TranslationItem,
+        result: &TranslationResult,
+        parent_qid: Option<&str>,
+    ) -> Result<(), String> {
+        self.translations.insert(
+            item.id.clone(),
+            json!({
+                "original_name": item.original_name,
+                "level": item.level.as_str(),
+                "parent_chain": item.parent_chain,
+                "parent_qid": parent_qid,
+                "cached_at": Utc::now().to_rfc3339(),
+                "translated": result.translated,
+                "qid": result.qid,
+                "source": result.source,
+                "used_lang": result.used_lang,
+                "parent_verified": result.parent_verified,
+            }),
+        );
+        self.index_name(item);
+        self.mark_dirty()
+    }
+
+    pub fn get_search_results(&self, item: &TranslationItem) -> Option<Vec<String>> {
+        self.search.get(&item.id).and_then(string_array)
+    }
+
+    pub fn set_search_results(
+        &mut self,
+        item: &TranslationItem,
+        qids: &[String],
+    ) -> Result<(), String> {
+        self.search.insert(item.id.clone(), json!(qids));
+        self.mark_dirty()
+    }
+
+    pub fn get_labels(&self, qid: &str) -> Option<HashMap<String, String>> {
+        value_to_string_map(self.labels.get(qid)?)
+    }
+
+    pub fn set_labels(
+        &mut self,
+        qid: &str,
+        labels: &HashMap<String, String>,
+    ) -> Result<(), String> {
+        self.labels.insert(qid.to_string(), json!(labels));
+        self.mark_dirty()
+    }
+
+    pub fn get_instance_of(&self, qid: &str) -> Option<Vec<String>> {
+        self.instance_of.get(qid).and_then(string_array)
+    }
+
+    pub fn set_instance_of(&mut self, qid: &str, values: &[String]) -> Result<(), String> {
+        self.instance_of.insert(qid.to_string(), json!(values));
+        self.mark_dirty()
+    }
+
+    pub fn get_p131(&self, candidate_qid: &str, parent_qid: &str) -> Option<bool> {
+        self.p131
+            .get(&p131_key(candidate_qid, parent_qid))
+            .and_then(Value::as_bool)
+    }
+
+    pub fn set_p131(
+        &mut self,
+        candidate_qid: &str,
+        parent_qid: &str,
+        value: bool,
+    ) -> Result<(), String> {
+        self.p131
+            .insert(p131_key(candidate_qid, parent_qid), Value::Bool(value));
+        self.mark_dirty()
+    }
+
+    pub fn flush_if_needed(
+        &mut self,
+        force: bool,
+        max_dirty: usize,
+        max_interval: Duration,
+    ) -> Result<(), String> {
+        if self.cache_path.is_none() {
+            self.dirty = 0;
+            self.last_flush = Instant::now();
+            return Ok(());
+        }
+        if !force && self.dirty < max_dirty && self.last_flush.elapsed() < max_interval {
+            return Ok(());
+        }
+        self.save()?;
+        self.dirty = 0;
+        self.last_flush = Instant::now();
+        Ok(())
+    }
+
+    pub fn save(&self) -> Result<(), String> {
+        let Some(path) = self.cache_path.as_deref() else {
+            return Ok(());
+        };
+        let root = json!({
+            "metadata": self.metadata,
+            "translations": self.translations,
+            "cache": {
+                "search": self.search,
+                "labels": self.labels,
+                "p131": self.p131,
+                "instance_of": self.instance_of,
+            },
+            "indexes": {
+                "by_name": self.indexes_by_name,
+            },
+        });
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|error| {
+                format!("無法建立 Wikidata cache 目錄 {}：{error}", parent.display())
+            })?;
+        }
+        let tmp_path = path.with_extension(format!(
+            "{}.tmp",
+            path.extension()
+                .and_then(|value| value.to_str())
+                .unwrap_or("json")
+        ));
+        let content = serde_json::to_string_pretty(&root)
+            .map_err(|error| format!("無法序列化 Wikidata cache：{error}"))?;
+        fs::write(&tmp_path, content).map_err(|error| {
+            format!(
+                "無法寫入 Wikidata cache 暫存檔 {}：{error}",
+                tmp_path.display()
+            )
+        })?;
+        fs::rename(&tmp_path, path)
+            .map_err(|error| format!("無法更新 Wikidata cache {}：{error}", path.display()))?;
+        Ok(())
+    }
+
+    fn empty(source_lang: String, target_lang: String, cache_path: Option<PathBuf>) -> Self {
+        Self {
+            cache_path,
+            metadata: Map::from_iter([
+                ("version".to_string(), Value::String(VERSION.to_string())),
+                ("source_lang".to_string(), Value::String(source_lang)),
+                ("target_lang".to_string(), Value::String(target_lang)),
+                (
+                    "created_at".to_string(),
+                    Value::String(Utc::now().to_rfc3339()),
+                ),
+                ("last_compacted_at".to_string(), Value::Null),
+            ]),
+            translations: Map::new(),
+            search: Map::new(),
+            labels: Map::new(),
+            p131: Map::new(),
+            instance_of: Map::new(),
+            indexes_by_name: Map::new(),
+            dirty: 0,
+            last_flush: Instant::now(),
+        }
+    }
+
+    fn mark_dirty(&mut self) -> Result<(), String> {
+        self.dirty += 1;
+        self.flush_if_needed(false, 20, Duration::from_secs(30))
+    }
+
+    fn index_name(&mut self, item: &TranslationItem) {
+        let entry = self
+            .indexes_by_name
+            .entry(item.original_name.clone())
+            .or_insert_with(|| Value::Array(Vec::new()));
+        let Some(values) = entry.as_array_mut() else {
+            return;
+        };
+        if !values.iter().any(|value| value.as_str() == Some(&item.id)) {
+            values.push(Value::String(item.id.clone()));
+        }
+    }
+}
+
+fn object_at(root: &Value, path: &[&str]) -> Option<Map<String, Value>> {
+    let mut current = root;
+    for key in path {
+        current = current.get(*key)?;
+    }
+    current.as_object().cloned()
+}
+
+fn string_field(entry: &Map<String, Value>, key: &str, default: &str) -> String {
+    entry
+        .get(key)
+        .and_then(Value::as_str)
+        .unwrap_or(default)
+        .to_string()
+}
+
+fn string_array(value: &Value) -> Option<Vec<String>> {
+    Some(
+        value
+            .as_array()?
+            .iter()
+            .filter_map(Value::as_str)
+            .map(ToString::to_string)
+            .collect(),
+    )
+}
+
+fn value_to_string_map(value: &Value) -> Option<HashMap<String, String>> {
+    Some(
+        value
+            .as_object()?
+            .iter()
+            .filter_map(|(key, value)| value.as_str().map(|value| (key.clone(), value.to_string())))
+            .collect(),
+    )
+}
+
+fn p131_key(candidate_qid: &str, parent_qid: &str) -> String {
+    format!("{candidate_qid}_{parent_qid}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wikidata::{AdminLevel, TranslationItem};
+
+    #[test]
+    fn cache_round_trips_context_aware_translation() {
+        let mut store = TranslationCacheStore::load("ko", "zh-tw", None).unwrap();
+        let item = TranslationItem::from_values(
+            AdminLevel::Admin2,
+            "중구",
+            "ko",
+            "zh-tw",
+            vec!["KR".to_string(), "서울특별시".to_string()],
+            HashMap::new(),
+        )
+        .unwrap();
+        let result = TranslationResult {
+            translated: "中區".to_string(),
+            qid: Some("Q12993".to_string()),
+            source: "wikidata".to_string(),
+            used_lang: "zh-tw".to_string(),
+            parent_verified: true,
+        };
+
+        store
+            .set_translation(&item, &result, Some("Q8684"))
+            .unwrap();
+
+        assert_eq!(store.get_translation(&item), Some(result));
+    }
+}

--- a/rust/src/wikidata/cache.rs
+++ b/rust/src/wikidata/cache.rs
@@ -180,6 +180,9 @@ impl TranslationCacheStore {
         max_dirty: usize,
         max_interval: Duration,
     ) -> Result<(), String> {
+        if self.dirty == 0 {
+            return Ok(());
+        }
         if self.cache_path.is_none() {
             self.dirty = 0;
             self.last_flush = Instant::now();
@@ -349,5 +352,52 @@ mod tests {
             .unwrap();
 
         assert_eq!(store.get_translation(&item), Some(result));
+    }
+
+    #[test]
+    fn force_flush_skips_clean_cache_without_creating_file() {
+        let path = unique_temp_cache_path("clean");
+        let mut store = TranslationCacheStore::load("ko", "zh-tw", Some(path.clone())).unwrap();
+
+        store
+            .flush_if_needed(true, 0, Duration::from_secs(0))
+            .unwrap();
+
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn force_flush_writes_dirty_cache() {
+        let path = unique_temp_cache_path("dirty");
+        let mut store = TranslationCacheStore::load("ko", "zh-tw", Some(path.clone())).unwrap();
+        let item = TranslationItem::from_values(
+            AdminLevel::Admin1,
+            "서울특별시",
+            "ko",
+            "zh-tw",
+            vec!["KR".to_string()],
+            HashMap::new(),
+        )
+        .unwrap();
+
+        store
+            .set_search_results(&item, &["Q8684".to_string()])
+            .unwrap();
+        store
+            .flush_if_needed(true, 0, Duration::from_secs(0))
+            .unwrap();
+
+        assert!(path.exists());
+        let _ = fs::remove_file(path);
+    }
+
+    fn unique_temp_cache_path(label: &str) -> PathBuf {
+        let suffix = format!(
+            "{}-{}-{}.json",
+            label,
+            std::process::id(),
+            Utc::now().timestamp_nanos_opt().unwrap()
+        );
+        std::env::temp_dir().join(format!("immich-wikidata-cache-test-{suffix}"))
     }
 }

--- a/rust/src/wikidata/cache.rs
+++ b/rust/src/wikidata/cache.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
-use std::fs;
+use std::fs::{self, File};
+use std::io::BufWriter;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
@@ -43,9 +44,9 @@ impl TranslationCacheStore {
             ));
         }
 
-        let content = fs::read_to_string(path)
+        let content = fs::read(path)
             .map_err(|error| format!("無法讀取 Wikidata cache {}：{error}", path.display()))?;
-        let root: Value = serde_json::from_str(&content)
+        let root: Value = serde_json::from_slice(&content)
             .map_err(|error| format!("Wikidata cache JSON 解析失敗 {}：{error}", path.display()))?;
         if let Some(version) = root
             .get("metadata")
@@ -225,14 +226,14 @@ impl TranslationCacheStore {
                 .and_then(|value| value.to_str())
                 .unwrap_or("json")
         ));
-        let content = serde_json::to_string_pretty(&root)
-            .map_err(|error| format!("無法序列化 Wikidata cache：{error}"))?;
-        fs::write(&tmp_path, content).map_err(|error| {
+        let file = File::create(&tmp_path).map_err(|error| {
             format!(
                 "無法寫入 Wikidata cache 暫存檔 {}：{error}",
                 tmp_path.display()
             )
         })?;
+        serde_json::to_writer_pretty(BufWriter::new(file), &root)
+            .map_err(|error| format!("無法序列化 Wikidata cache：{error}"))?;
         fs::rename(&tmp_path, path)
             .map_err(|error| format!("無法更新 Wikidata cache {}：{error}", path.display()))?;
         Ok(())

--- a/rust/src/wikidata/client.rs
+++ b/rust/src/wikidata/client.rs
@@ -37,7 +37,7 @@ pub trait WikidataApi {
         &self,
         qids: &[String],
         props: &str,
-        languages: &[String],
+        languages: &str,
     ) -> Result<String, String>;
     fn ask_p131_json(&self, candidate_qid: &str, parent_qid: &str) -> Result<String, String>;
     fn zhwiki_convert_title_json(&self, title: &str) -> Result<String, String>;
@@ -75,7 +75,7 @@ impl WikidataApi for WikidataHttpClient {
         &self,
         qids: &[String],
         props: &str,
-        languages: &[String],
+        languages: &str,
     ) -> Result<String, String> {
         self.http
             .get_text(get_entities_url(qids, props, languages)?.as_str())
@@ -106,7 +106,7 @@ pub fn search_entities_url(name: &str, source_lang: &str, limit: usize) -> Resul
     Ok(url)
 }
 
-pub fn get_entities_url(qids: &[String], props: &str, languages: &[String]) -> Result<Url, String> {
+pub fn get_entities_url(qids: &[String], props: &str, languages: &str) -> Result<Url, String> {
     let mut url =
         Url::parse(WDACT_URL).map_err(|error| format!("Wikidata API URL 錯誤：{error}"))?;
     url.query_pairs_mut()
@@ -114,7 +114,7 @@ pub fn get_entities_url(qids: &[String], props: &str, languages: &[String]) -> R
         .append_pair("action", "wbgetentities")
         .append_pair("ids", &qids.join("|"))
         .append_pair("props", props)
-        .append_pair("languages", &languages.join("|"));
+        .append_pair("languages", languages);
     Ok(url)
 }
 
@@ -158,7 +158,7 @@ mod tests {
         let url = get_entities_url(
             &["Q1".to_string(), "Q2".to_string()],
             "labels|sitelinks",
-            &["zh-tw".to_string(), "zh".to_string()],
+            "zh-tw|zh",
         )
         .unwrap();
         let params: Vec<_> = url.query_pairs().collect();

--- a/rust/src/wikidata/client.rs
+++ b/rust/src/wikidata/client.rs
@@ -31,6 +31,18 @@ impl WikidataClientOptions {
     }
 }
 
+pub trait WikidataApi {
+    fn search_entities_json(&self, name: &str, limit: usize) -> Result<String, String>;
+    fn get_entities_json(
+        &self,
+        qids: &[String],
+        props: &str,
+        languages: &[String],
+    ) -> Result<String, String>;
+    fn ask_p131_json(&self, candidate_qid: &str, parent_qid: &str) -> Result<String, String>;
+    fn zhwiki_convert_title_json(&self, title: &str) -> Result<String, String>;
+}
+
 #[derive(Debug, Clone)]
 pub struct WikidataHttpClient {
     options: WikidataClientOptions,
@@ -43,6 +55,7 @@ impl WikidataHttpClient {
             user_agent: "immich-geodata-zh-tw/1.0 (Rust Wikidata Translation Tool)".to_string(),
             timeout: Duration::from_secs(30),
             max_retries: 5,
+            throttle_after_success: Duration::from_millis(200),
             ..HttpRequestPolicy::default()
         };
         Ok(Self {
@@ -50,18 +63,30 @@ impl WikidataHttpClient {
             http: HttpClient::new(policy)?,
         })
     }
+}
 
-    pub fn search_entities_json(&self, name: &str, limit: usize) -> Result<String, String> {
+impl WikidataApi for WikidataHttpClient {
+    fn search_entities_json(&self, name: &str, limit: usize) -> Result<String, String> {
         self.http
             .get_text(search_entities_url(name, &self.options.source_lang, limit)?.as_str())
     }
 
-    pub fn ask_p131_json(&self, candidate_qid: &str, parent_qid: &str) -> Result<String, String> {
+    fn get_entities_json(
+        &self,
+        qids: &[String],
+        props: &str,
+        languages: &[String],
+    ) -> Result<String, String> {
+        self.http
+            .get_text(get_entities_url(qids, props, languages)?.as_str())
+    }
+
+    fn ask_p131_json(&self, candidate_qid: &str, parent_qid: &str) -> Result<String, String> {
         let query = format!("ASK {{ wd:{candidate_qid} (wdt:P131)+ wd:{parent_qid} . }}");
         self.http.get_text(wdqs_url(&query)?.as_str())
     }
 
-    pub fn zhwiki_convert_title_json(&self, title: &str) -> Result<String, String> {
+    fn zhwiki_convert_title_json(&self, title: &str) -> Result<String, String> {
         self.http
             .get_text(zhwiki_convert_title_url(title)?.as_str())
     }
@@ -78,6 +103,18 @@ pub fn search_entities_url(name: &str, source_lang: &str, limit: usize) -> Resul
         .append_pair("uselang", source_lang)
         .append_pair("type", "item")
         .append_pair("limit", &limit.to_string());
+    Ok(url)
+}
+
+pub fn get_entities_url(qids: &[String], props: &str, languages: &[String]) -> Result<Url, String> {
+    let mut url =
+        Url::parse(WDACT_URL).map_err(|error| format!("Wikidata API URL 錯誤：{error}"))?;
+    url.query_pairs_mut()
+        .append_pair("format", "json")
+        .append_pair("action", "wbgetentities")
+        .append_pair("ids", &qids.join("|"))
+        .append_pair("props", props)
+        .append_pair("languages", &languages.join("|"));
     Ok(url)
 }
 
@@ -114,6 +151,22 @@ mod tests {
         assert!(params.contains(&("uselang".into(), "ko".into())));
         assert!(params.contains(&("type".into(), "item".into())));
         assert!(params.contains(&("limit".into(), "7".into())));
+    }
+
+    #[test]
+    fn get_entities_url_uses_batch_contract() {
+        let url = get_entities_url(
+            &["Q1".to_string(), "Q2".to_string()],
+            "labels|sitelinks",
+            &["zh-tw".to_string(), "zh".to_string()],
+        )
+        .unwrap();
+        let params: Vec<_> = url.query_pairs().collect();
+
+        assert!(params.contains(&("action".into(), "wbgetentities".into())));
+        assert!(params.contains(&("ids".into(), "Q1|Q2".into())));
+        assert!(params.contains(&("props".into(), "labels|sitelinks".into())));
+        assert!(params.contains(&("languages".into(), "zh-tw|zh".into())));
     }
 
     #[test]

--- a/rust/src/wikidata/mod.rs
+++ b/rust/src/wikidata/mod.rs
@@ -1,0 +1,20 @@
+mod cache;
+mod client;
+mod translator;
+mod types;
+
+#[cfg(test)]
+mod translator_tests;
+
+pub use cache::TranslationCacheStore;
+pub use client::{
+    WDACT_URL, WDQS_URL, WikidataApi, WikidataClientOptions, WikidataHttpClient, ZHWIKI_URL,
+    get_entities_url, search_entities_url, wdqs_url, zhwiki_convert_title_url,
+};
+pub use translator::{
+    BatchTranslateOptions, WikidataCandidateMetadata, WikidataTranslator, dedupe_keep_order,
+};
+pub use types::{
+    AdminLevel, TranslationDataset, TranslationDatasetBuilder, TranslationItem, TranslationResult,
+    build_translation_item_id,
+};

--- a/rust/src/wikidata/translator.rs
+++ b/rust/src/wikidata/translator.rs
@@ -39,6 +39,8 @@ pub struct WikidataCandidateMetadata {
 
 pub struct WikidataTranslator<C: WikidataApi> {
     options: WikidataClientOptions,
+    label_languages: Vec<String>,
+    claim_languages: Vec<String>,
     client: C,
     pub cache_store: TranslationCacheStore,
     opencc: Option<Converter>,
@@ -62,6 +64,11 @@ impl<C: WikidataApi> WikidataTranslator<C> {
         cache_path: Option<PathBuf>,
         use_opencc: bool,
     ) -> Result<Self, String> {
+        let label_languages = dedupe_keep_order(
+            [options.target_lang.clone()]
+                .into_iter()
+                .chain(options.fallback_langs.iter().cloned()),
+        );
         let opencc = if use_opencc {
             Some(
                 opencc_rust::presets::cn2t::converter("cn", "t")
@@ -77,6 +84,8 @@ impl<C: WikidataApi> WikidataTranslator<C> {
         )?;
         Ok(Self {
             options,
+            label_languages,
+            claim_languages: vec!["en".to_string()],
             client,
             cache_store,
             opencc,
@@ -92,32 +101,22 @@ impl<C: WikidataApi> WikidataTranslator<C> {
             return Ok(HashMap::new());
         }
         let batch_size = options.batch_size.max(1);
-        let mut search_results = HashMap::<String, SearchData>::new();
+        let mut results = HashMap::with_capacity(dataset.len());
+        let mut pending = Vec::<SearchData>::new();
         let mut cache_hits = 0_usize;
 
         for batch in dataset.items().chunks(batch_size) {
             for item in batch {
                 if let Some(result) = self.cache_store.get_translation(item) {
                     cache_hits += 1;
-                    search_results.insert(
-                        item.id.clone(),
-                        SearchData {
-                            item: item.clone(),
-                            cached: Some(result),
-                            qids: Vec::new(),
-                        },
-                    );
+                    results.insert(item.id.clone(), result);
                     continue;
                 }
                 let qids = self.search_wikidata(item);
-                search_results.insert(
-                    item.id.clone(),
-                    SearchData {
-                        item: item.clone(),
-                        cached: None,
-                        qids,
-                    },
-                );
+                pending.push(SearchData {
+                    item: item.clone(),
+                    qids,
+                });
             }
         }
 
@@ -129,25 +128,14 @@ impl<C: WikidataApi> WikidataTranslator<C> {
         );
 
         if let Some(candidate_filter) = options.candidate_filter {
-            self.apply_candidate_filter(&mut search_results, candidate_filter)?;
+            self.apply_candidate_filter(&mut pending, candidate_filter)?;
         }
 
-        let all_qids = dedupe_keep_order(
-            search_results
-                .values()
-                .filter(|data| data.cached.is_none())
-                .flat_map(|data| data.qids.iter().cloned()),
-        );
+        let all_qids = dedupe_keep_order(pending.iter().flat_map(|data| data.qids.iter().cloned()));
         let all_labels = self.batch_get_labels(&all_qids)?;
-        let mut results = HashMap::new();
         let mut fallback_count = 0_usize;
 
-        for (item_id, data) in search_results {
-            if let Some(result) = data.cached {
-                results.insert(item_id, result);
-                continue;
-            }
-
+        for data in pending {
             let parent_qid = options
                 .parent_qids
                 .get(&data.item.id)
@@ -158,19 +146,19 @@ impl<C: WikidataApi> WikidataTranslator<C> {
                 self.cache_store
                     .set_translation(&data.item, &result, parent_qid)?;
                 fallback_count += 1;
-                results.insert(item_id, result);
+                results.insert(data.item.id, result);
                 continue;
             };
 
-            let labels = all_labels.get(&selected_qid).cloned().unwrap_or_default();
-            let mut result = self.select_best_label(&labels, &data.item.original_name);
+            let mut result =
+                self.select_best_label(all_labels.get(&selected_qid), &data.item.original_name);
             result.qid = Some(selected_qid.clone());
             if let Some(parent_qid) = parent_qid {
                 result.parent_verified = self.verify_p131(&selected_qid, parent_qid)?;
             }
             self.cache_store
                 .set_translation(&data.item, &result, parent_qid)?;
-            results.insert(item_id, result);
+            results.insert(data.item.id, result);
         }
 
         self.cache_store
@@ -200,21 +188,17 @@ impl<C: WikidataApi> WikidataTranslator<C> {
 
     fn apply_candidate_filter(
         &mut self,
-        search_results: &mut HashMap<String, SearchData>,
+        search_results: &mut [SearchData],
         candidate_filter: &dyn Fn(&str, &WikidataCandidateMetadata) -> bool,
     ) -> Result<(), String> {
         let qids = dedupe_keep_order(
             search_results
-                .values()
-                .filter(|data| data.cached.is_none())
+                .iter()
                 .flat_map(|data| data.qids.iter().cloned()),
         );
         let labels = self.batch_get_labels(&qids)?;
         let instance_of = self.batch_get_instance_of(&qids)?;
-        for data in search_results.values_mut() {
-            if data.cached.is_some() {
-                continue;
-            }
+        for data in search_results {
             data.qids.retain(|qid| {
                 let metadata = WikidataCandidateMetadata {
                     qid: qid.clone(),
@@ -241,15 +225,10 @@ impl<C: WikidataApi> WikidataTranslator<C> {
                 uncached.push(qid.clone());
             }
         }
-        let languages = dedupe_keep_order(
-            [self.options.target_lang.clone()]
-                .into_iter()
-                .chain(self.options.fallback_langs.iter().cloned()),
-        );
         for batch in uncached.chunks(ENTITY_BATCH_SIZE) {
-            let Ok(body) = self
-                .client
-                .get_entities_json(batch, "labels|sitelinks", &languages)
+            let Ok(body) =
+                self.client
+                    .get_entities_json(batch, "labels|sitelinks", &self.label_languages)
             else {
                 continue;
             };
@@ -278,7 +257,7 @@ impl<C: WikidataApi> WikidataTranslator<C> {
         for batch in uncached.chunks(ENTITY_BATCH_SIZE) {
             let Ok(body) = self
                 .client
-                .get_entities_json(batch, "claims", &["en".to_string()])
+                .get_entities_json(batch, "claims", &self.claim_languages)
             else {
                 continue;
             };
@@ -323,9 +302,12 @@ impl<C: WikidataApi> WikidataTranslator<C> {
 
     fn select_best_label(
         &self,
-        labels: &HashMap<String, String>,
+        labels: Option<&HashMap<String, String>>,
         original_name: &str,
     ) -> TranslationResult {
+        let Some(labels) = labels else {
+            return TranslationResult::original(original_name);
+        };
         if let Some(label) = labels.get(&self.options.target_lang) {
             return wikidata_result(label, "wikidata", &self.options.target_lang);
         }
@@ -355,7 +337,6 @@ impl<C: WikidataApi> WikidataTranslator<C> {
 #[derive(Clone, Debug)]
 struct SearchData {
     item: TranslationItem,
-    cached: Option<TranslationResult>,
     qids: Vec<String>,
 }
 

--- a/rust/src/wikidata/translator.rs
+++ b/rust/src/wikidata/translator.rs
@@ -1,0 +1,485 @@
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::time::Duration;
+
+use opencc_rust::Converter;
+use serde_json::Value;
+
+use super::cache::TranslationCacheStore;
+use super::client::{WikidataApi, WikidataClientOptions, WikidataHttpClient};
+use super::types::{TranslationDataset, TranslationItem, TranslationResult};
+
+const SEARCH_LIMIT: usize = 7;
+const ENTITY_BATCH_SIZE: usize = 50;
+
+pub struct BatchTranslateOptions<'a> {
+    pub batch_size: usize,
+    pub parent_qids: HashMap<String, String>,
+    pub candidate_filter: Option<&'a CandidateFilter>,
+}
+
+pub type CandidateFilter = dyn Fn(&str, &WikidataCandidateMetadata) -> bool;
+
+impl Default for BatchTranslateOptions<'_> {
+    fn default() -> Self {
+        Self {
+            batch_size: 20,
+            parent_qids: HashMap::new(),
+            candidate_filter: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WikidataCandidateMetadata {
+    pub qid: String,
+    pub labels: HashMap<String, String>,
+    pub instance_of: Vec<String>,
+}
+
+pub struct WikidataTranslator<C: WikidataApi> {
+    options: WikidataClientOptions,
+    client: C,
+    pub cache_store: TranslationCacheStore,
+    opencc: Option<Converter>,
+}
+
+impl WikidataTranslator<WikidataHttpClient> {
+    pub fn new(
+        options: WikidataClientOptions,
+        cache_path: Option<PathBuf>,
+        use_opencc: bool,
+    ) -> Result<Self, String> {
+        let client = WikidataHttpClient::new(options.clone())?;
+        Self::with_client(options, client, cache_path, use_opencc)
+    }
+}
+
+impl<C: WikidataApi> WikidataTranslator<C> {
+    pub fn with_client(
+        options: WikidataClientOptions,
+        client: C,
+        cache_path: Option<PathBuf>,
+        use_opencc: bool,
+    ) -> Result<Self, String> {
+        let opencc = if use_opencc {
+            Some(
+                opencc_rust::presets::cn2t::converter("cn", "t")
+                    .map_err(|error| format!("無法建立 OpenCC native converter：{error}"))?,
+            )
+        } else {
+            None
+        };
+        let cache_store = TranslationCacheStore::load(
+            options.source_lang.clone(),
+            options.target_lang.clone(),
+            cache_path,
+        )?;
+        Ok(Self {
+            options,
+            client,
+            cache_store,
+            opencc,
+        })
+    }
+
+    pub fn batch_translate(
+        &mut self,
+        dataset: &TranslationDataset,
+        options: BatchTranslateOptions<'_>,
+    ) -> Result<HashMap<String, TranslationResult>, String> {
+        if dataset.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let batch_size = options.batch_size.max(1);
+        let mut search_results = HashMap::<String, SearchData>::new();
+        let mut cache_hits = 0_usize;
+
+        for batch in dataset.items().chunks(batch_size) {
+            for item in batch {
+                if let Some(result) = self.cache_store.get_translation(item) {
+                    cache_hits += 1;
+                    search_results.insert(
+                        item.id.clone(),
+                        SearchData {
+                            item: item.clone(),
+                            cached: Some(result),
+                            qids: Vec::new(),
+                        },
+                    );
+                    continue;
+                }
+                let qids = self.search_wikidata(item);
+                search_results.insert(
+                    item.id.clone(),
+                    SearchData {
+                        item: item.clone(),
+                        cached: None,
+                        qids,
+                    },
+                );
+            }
+        }
+
+        println!(
+            "stage=wikidata phase=search level={} total={} cache_hits={}",
+            dataset.level.as_str(),
+            dataset.len(),
+            cache_hits
+        );
+
+        if let Some(candidate_filter) = options.candidate_filter {
+            self.apply_candidate_filter(&mut search_results, candidate_filter)?;
+        }
+
+        let all_qids = dedupe_keep_order(
+            search_results
+                .values()
+                .filter(|data| data.cached.is_none())
+                .flat_map(|data| data.qids.iter().cloned()),
+        );
+        let all_labels = self.batch_get_labels(&all_qids)?;
+        let mut results = HashMap::new();
+        let mut fallback_count = 0_usize;
+
+        for (item_id, data) in search_results {
+            if let Some(result) = data.cached {
+                results.insert(item_id, result);
+                continue;
+            }
+
+            let parent_qid = options
+                .parent_qids
+                .get(&data.item.id)
+                .or_else(|| options.parent_qids.get(&data.item.original_name))
+                .map(String::as_str);
+            let Some(selected_qid) = self.select_qid(&data.qids, parent_qid)? else {
+                let result = TranslationResult::original(&data.item.original_name);
+                self.cache_store
+                    .set_translation(&data.item, &result, parent_qid)?;
+                fallback_count += 1;
+                results.insert(item_id, result);
+                continue;
+            };
+
+            let labels = all_labels.get(&selected_qid).cloned().unwrap_or_default();
+            let mut result = self.select_best_label(&labels, &data.item.original_name);
+            result.qid = Some(selected_qid.clone());
+            if let Some(parent_qid) = parent_qid {
+                result.parent_verified = self.verify_p131(&selected_qid, parent_qid)?;
+            }
+            self.cache_store
+                .set_translation(&data.item, &result, parent_qid)?;
+            results.insert(item_id, result);
+        }
+
+        self.cache_store
+            .flush_if_needed(true, 0, Duration::from_secs(0))?;
+        println!(
+            "stage=wikidata phase=translate level={} total={} fallback={}",
+            dataset.level.as_str(),
+            dataset.len(),
+            fallback_count
+        );
+        Ok(results)
+    }
+
+    fn search_wikidata(&mut self, item: &TranslationItem) -> Vec<String> {
+        if let Some(qids) = self.cache_store.get_search_results(item) {
+            return qids;
+        }
+        let qids = self
+            .client
+            .search_entities_json(&item.original_name, SEARCH_LIMIT)
+            .ok()
+            .and_then(|json| parse_search_qids(&json).ok())
+            .unwrap_or_default();
+        let _ = self.cache_store.set_search_results(item, &qids);
+        qids
+    }
+
+    fn apply_candidate_filter(
+        &mut self,
+        search_results: &mut HashMap<String, SearchData>,
+        candidate_filter: &dyn Fn(&str, &WikidataCandidateMetadata) -> bool,
+    ) -> Result<(), String> {
+        let qids = dedupe_keep_order(
+            search_results
+                .values()
+                .filter(|data| data.cached.is_none())
+                .flat_map(|data| data.qids.iter().cloned()),
+        );
+        let labels = self.batch_get_labels(&qids)?;
+        let instance_of = self.batch_get_instance_of(&qids)?;
+        for data in search_results.values_mut() {
+            if data.cached.is_some() {
+                continue;
+            }
+            data.qids.retain(|qid| {
+                let metadata = WikidataCandidateMetadata {
+                    qid: qid.clone(),
+                    labels: labels.get(qid).cloned().unwrap_or_default(),
+                    instance_of: instance_of.get(qid).cloned().unwrap_or_default(),
+                };
+                candidate_filter(&data.item.original_name, &metadata)
+            });
+        }
+        Ok(())
+    }
+
+    fn batch_get_labels(
+        &mut self,
+        qids: &[String],
+    ) -> Result<HashMap<String, HashMap<String, String>>, String> {
+        let unique_qids = dedupe_keep_order(qids.iter().cloned());
+        let mut results = HashMap::new();
+        let mut uncached = Vec::new();
+        for qid in &unique_qids {
+            if let Some(labels) = self.cache_store.get_labels(qid) {
+                results.insert(qid.clone(), labels);
+            } else {
+                uncached.push(qid.clone());
+            }
+        }
+        let languages = dedupe_keep_order(
+            [self.options.target_lang.clone()]
+                .into_iter()
+                .chain(self.options.fallback_langs.iter().cloned()),
+        );
+        for batch in uncached.chunks(ENTITY_BATCH_SIZE) {
+            let Ok(body) = self
+                .client
+                .get_entities_json(batch, "labels|sitelinks", &languages)
+            else {
+                continue;
+            };
+            for (qid, labels) in parse_entity_labels(&body)? {
+                self.cache_store.set_labels(&qid, &labels)?;
+                results.insert(qid, labels);
+            }
+        }
+        Ok(results)
+    }
+
+    fn batch_get_instance_of(
+        &mut self,
+        qids: &[String],
+    ) -> Result<HashMap<String, Vec<String>>, String> {
+        let unique_qids = dedupe_keep_order(qids.iter().cloned());
+        let mut results = HashMap::new();
+        let mut uncached = Vec::new();
+        for qid in &unique_qids {
+            if let Some(values) = self.cache_store.get_instance_of(qid) {
+                results.insert(qid.clone(), values);
+            } else {
+                uncached.push(qid.clone());
+            }
+        }
+        for batch in uncached.chunks(ENTITY_BATCH_SIZE) {
+            let Ok(body) = self
+                .client
+                .get_entities_json(batch, "claims", &["en".to_string()])
+            else {
+                continue;
+            };
+            for (qid, values) in parse_entity_instance_of(&body)? {
+                self.cache_store.set_instance_of(&qid, &values)?;
+                results.insert(qid, values);
+            }
+        }
+        Ok(results)
+    }
+
+    fn select_qid(
+        &mut self,
+        qids: &[String],
+        parent_qid: Option<&str>,
+    ) -> Result<Option<String>, String> {
+        let Some(parent_qid) = parent_qid else {
+            return Ok(qids.first().cloned());
+        };
+        for qid in qids {
+            if self.verify_p131(qid, parent_qid)? {
+                return Ok(Some(qid.clone()));
+            }
+        }
+        Ok(qids.first().cloned())
+    }
+
+    fn verify_p131(&mut self, candidate_qid: &str, parent_qid: &str) -> Result<bool, String> {
+        if let Some(value) = self.cache_store.get_p131(candidate_qid, parent_qid) {
+            return Ok(value);
+        }
+        let value = self
+            .client
+            .ask_p131_json(candidate_qid, parent_qid)
+            .ok()
+            .and_then(|json| parse_p131_answer(&json).ok())
+            .unwrap_or(false);
+        self.cache_store
+            .set_p131(candidate_qid, parent_qid, value)?;
+        Ok(value)
+    }
+
+    fn select_best_label(
+        &self,
+        labels: &HashMap<String, String>,
+        original_name: &str,
+    ) -> TranslationResult {
+        if let Some(label) = labels.get(&self.options.target_lang) {
+            return wikidata_result(label, "wikidata", &self.options.target_lang);
+        }
+        for lang in &self.options.fallback_langs {
+            if let Some(label) = labels.get(lang) {
+                if lang == "zh" {
+                    if let Some(converter) = &self.opencc {
+                        return wikidata_result(&converter.convert(label), "opencc", "zh→zh-tw");
+                    }
+                    return wikidata_result(label, "wikidata-zh", "zh");
+                }
+                return wikidata_result(label, &format!("wikidata-{lang}"), lang);
+            }
+        }
+        if let Some(title) = labels.get("zhwiki") {
+            if let Ok(body) = self.client.zhwiki_convert_title_json(title)
+                && let Ok(converted) = parse_zhwiki_converted_title(&body)
+            {
+                return wikidata_result(&converted, "zhwiki-convert", "zhwiki");
+            }
+            return wikidata_result(title, "zhwiki", "zhwiki");
+        }
+        TranslationResult::original(original_name)
+    }
+}
+
+#[derive(Clone, Debug)]
+struct SearchData {
+    item: TranslationItem,
+    cached: Option<TranslationResult>,
+    qids: Vec<String>,
+}
+
+pub fn dedupe_keep_order(values: impl IntoIterator<Item = String>) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut deduped = Vec::new();
+    for value in values {
+        if seen.insert(value.clone()) {
+            deduped.push(value);
+        }
+    }
+    deduped
+}
+
+fn wikidata_result(translated: &str, source: &str, used_lang: &str) -> TranslationResult {
+    TranslationResult {
+        translated: translated.to_string(),
+        qid: None,
+        source: source.to_string(),
+        used_lang: used_lang.to_string(),
+        parent_verified: false,
+    }
+}
+
+fn parse_search_qids(body: &str) -> Result<Vec<String>, String> {
+    let root: Value = serde_json::from_str(body)
+        .map_err(|error| format!("Wikidata search JSON 解析失敗：{error}"))?;
+    Ok(root
+        .get("search")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| entry.get("id").and_then(Value::as_str))
+        .map(ToString::to_string)
+        .collect())
+}
+
+fn parse_entity_labels(body: &str) -> Result<HashMap<String, HashMap<String, String>>, String> {
+    let root: Value = serde_json::from_str(body)
+        .map_err(|error| format!("Wikidata labels JSON 解析失敗：{error}"))?;
+    let mut results = HashMap::new();
+    let Some(entities) = root.get("entities").and_then(Value::as_object) else {
+        return Ok(results);
+    };
+    for (qid, entity) in entities {
+        let mut labels = HashMap::new();
+        if let Some(label_map) = entity.get("labels").and_then(Value::as_object) {
+            for (lang, label) in label_map {
+                if let Some(value) = label.get("value").and_then(Value::as_str) {
+                    labels.insert(lang.clone(), value.to_string());
+                }
+            }
+        }
+        if let Some(title) = entity
+            .get("sitelinks")
+            .and_then(|value| value.get("zhwiki"))
+            .and_then(|value| value.get("title"))
+            .and_then(Value::as_str)
+        {
+            labels.insert("zhwiki".to_string(), title.to_string());
+        }
+        results.insert(qid.clone(), labels);
+    }
+    Ok(results)
+}
+
+fn parse_entity_instance_of(body: &str) -> Result<HashMap<String, Vec<String>>, String> {
+    let root: Value = serde_json::from_str(body)
+        .map_err(|error| format!("Wikidata P31 JSON 解析失敗：{error}"))?;
+    let mut results = HashMap::new();
+    let Some(entities) = root.get("entities").and_then(Value::as_object) else {
+        return Ok(results);
+    };
+    for (qid, entity) in entities {
+        let mut values = Vec::new();
+        if let Some(claims) = entity
+            .get("claims")
+            .and_then(|claims| claims.get("P31"))
+            .and_then(Value::as_array)
+        {
+            for claim in claims {
+                if let Some(id) = claim
+                    .get("mainsnak")
+                    .and_then(|value| value.get("datavalue"))
+                    .and_then(|value| value.get("value"))
+                    .and_then(|value| value.get("id"))
+                    .and_then(Value::as_str)
+                {
+                    values.push(id.to_string());
+                }
+            }
+        }
+        results.insert(qid.clone(), values);
+    }
+    Ok(results)
+}
+
+fn parse_p131_answer(body: &str) -> Result<bool, String> {
+    let root: Value = serde_json::from_str(body)
+        .map_err(|error| format!("Wikidata P131 JSON 解析失敗：{error}"))?;
+    root.get("boolean")
+        .and_then(Value::as_bool)
+        .ok_or_else(|| "Wikidata P131 回應缺少 boolean".to_string())
+}
+
+pub(super) fn parse_zhwiki_converted_title(body: &str) -> Result<String, String> {
+    let root: Value = serde_json::from_str(body)
+        .map_err(|error| format!("中文維基轉換 JSON 解析失敗：{error}"))?;
+    if let Some(converted) = root
+        .get("query")
+        .and_then(|query| query.get("converted"))
+        .and_then(Value::as_array)
+        .and_then(|values| values.first())
+        .and_then(|value| value.get("to"))
+        .and_then(Value::as_str)
+    {
+        return Ok(converted.to_string());
+    }
+    root.get("query")
+        .and_then(|query| query.get("pages"))
+        .and_then(Value::as_object)
+        .and_then(|pages| pages.values().next())
+        .and_then(|page| page.get("title"))
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .ok_or_else(|| "中文維基轉換回應缺少 title".to_string())
+}

--- a/rust/src/wikidata/translator.rs
+++ b/rust/src/wikidata/translator.rs
@@ -11,6 +11,7 @@ use super::types::{TranslationDataset, TranslationItem, TranslationResult};
 
 const SEARCH_LIMIT: usize = 7;
 const ENTITY_BATCH_SIZE: usize = 50;
+const CLAIM_LANGUAGES: &str = "en";
 
 pub struct BatchTranslateOptions<'a> {
     pub batch_size: usize,
@@ -18,7 +19,7 @@ pub struct BatchTranslateOptions<'a> {
     pub candidate_filter: Option<&'a CandidateFilter>,
 }
 
-pub type CandidateFilter = dyn Fn(&str, &WikidataCandidateMetadata) -> bool;
+pub type CandidateFilter = dyn for<'a> Fn(&str, &WikidataCandidateMetadata<'a>) -> bool;
 
 impl Default for BatchTranslateOptions<'_> {
     fn default() -> Self {
@@ -30,17 +31,16 @@ impl Default for BatchTranslateOptions<'_> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct WikidataCandidateMetadata {
-    pub qid: String,
-    pub labels: HashMap<String, String>,
-    pub instance_of: Vec<String>,
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct WikidataCandidateMetadata<'a> {
+    pub qid: &'a str,
+    pub labels: &'a HashMap<String, String>,
+    pub instance_of: &'a [String],
 }
 
 pub struct WikidataTranslator<C: WikidataApi> {
     options: WikidataClientOptions,
-    label_languages: Vec<String>,
-    claim_languages: Vec<String>,
+    label_languages: String,
     client: C,
     pub cache_store: TranslationCacheStore,
     opencc: Option<Converter>,
@@ -68,7 +68,8 @@ impl<C: WikidataApi> WikidataTranslator<C> {
             [options.target_lang.clone()]
                 .into_iter()
                 .chain(options.fallback_langs.iter().cloned()),
-        );
+        )
+        .join("|");
         let opencc = if use_opencc {
             Some(
                 opencc_rust::presets::cn2t::converter("cn", "t")
@@ -85,7 +86,6 @@ impl<C: WikidataApi> WikidataTranslator<C> {
         Ok(Self {
             options,
             label_languages,
-            claim_languages: vec!["en".to_string()],
             client,
             cache_store,
             opencc,
@@ -102,7 +102,7 @@ impl<C: WikidataApi> WikidataTranslator<C> {
         }
         let batch_size = options.batch_size.max(1);
         let mut results = HashMap::with_capacity(dataset.len());
-        let mut pending = Vec::<SearchData>::new();
+        let mut pending = Vec::<SearchData>::with_capacity(dataset.len());
         let mut cache_hits = 0_usize;
 
         for batch in dataset.items().chunks(batch_size) {
@@ -127,12 +127,19 @@ impl<C: WikidataApi> WikidataTranslator<C> {
             cache_hits
         );
 
-        if let Some(candidate_filter) = options.candidate_filter {
-            self.apply_candidate_filter(&mut pending, candidate_filter)?;
-        }
+        let prefetched_labels = if let Some(candidate_filter) = options.candidate_filter {
+            Some(self.apply_candidate_filter(&mut pending, candidate_filter)?)
+        } else {
+            None
+        };
 
-        let all_qids = dedupe_keep_order(pending.iter().flat_map(|data| data.qids.iter().cloned()));
-        let all_labels = self.batch_get_labels(&all_qids)?;
+        let all_labels = if let Some(labels) = prefetched_labels {
+            labels
+        } else {
+            let all_qids =
+                dedupe_keep_order(pending.iter().flat_map(|data| data.qids.iter().cloned()));
+            self.batch_get_labels(&all_qids)?
+        };
         let mut fallback_count = 0_usize;
 
         for data in pending {
@@ -189,8 +196,8 @@ impl<C: WikidataApi> WikidataTranslator<C> {
     fn apply_candidate_filter(
         &mut self,
         search_results: &mut [SearchData],
-        candidate_filter: &dyn Fn(&str, &WikidataCandidateMetadata) -> bool,
-    ) -> Result<(), String> {
+        candidate_filter: &CandidateFilter,
+    ) -> Result<HashMap<String, HashMap<String, String>>, String> {
         let qids = dedupe_keep_order(
             search_results
                 .iter()
@@ -199,16 +206,21 @@ impl<C: WikidataApi> WikidataTranslator<C> {
         let labels = self.batch_get_labels(&qids)?;
         let instance_of = self.batch_get_instance_of(&qids)?;
         for data in search_results {
+            let empty_labels = HashMap::new();
+            let empty_instance_of = Vec::new();
             data.qids.retain(|qid| {
                 let metadata = WikidataCandidateMetadata {
-                    qid: qid.clone(),
-                    labels: labels.get(qid).cloned().unwrap_or_default(),
-                    instance_of: instance_of.get(qid).cloned().unwrap_or_default(),
+                    qid,
+                    labels: labels.get(qid).unwrap_or(&empty_labels),
+                    instance_of: instance_of
+                        .get(qid)
+                        .map(Vec::as_slice)
+                        .unwrap_or(empty_instance_of.as_slice()),
                 };
                 candidate_filter(&data.item.original_name, &metadata)
             });
         }
-        Ok(())
+        Ok(labels)
     }
 
     fn batch_get_labels(
@@ -216,7 +228,7 @@ impl<C: WikidataApi> WikidataTranslator<C> {
         qids: &[String],
     ) -> Result<HashMap<String, HashMap<String, String>>, String> {
         let unique_qids = dedupe_keep_order(qids.iter().cloned());
-        let mut results = HashMap::new();
+        let mut results = HashMap::with_capacity(unique_qids.len());
         let mut uncached = Vec::new();
         for qid in &unique_qids {
             if let Some(labels) = self.cache_store.get_labels(qid) {
@@ -245,7 +257,7 @@ impl<C: WikidataApi> WikidataTranslator<C> {
         qids: &[String],
     ) -> Result<HashMap<String, Vec<String>>, String> {
         let unique_qids = dedupe_keep_order(qids.iter().cloned());
-        let mut results = HashMap::new();
+        let mut results = HashMap::with_capacity(unique_qids.len());
         let mut uncached = Vec::new();
         for qid in &unique_qids {
             if let Some(values) = self.cache_store.get_instance_of(qid) {
@@ -257,7 +269,7 @@ impl<C: WikidataApi> WikidataTranslator<C> {
         for batch in uncached.chunks(ENTITY_BATCH_SIZE) {
             let Ok(body) = self
                 .client
-                .get_entities_json(batch, "claims", &self.claim_languages)
+                .get_entities_json(batch, "claims", CLAIM_LANGUAGES)
             else {
                 continue;
             };
@@ -334,7 +346,7 @@ impl<C: WikidataApi> WikidataTranslator<C> {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 struct SearchData {
     item: TranslationItem,
     qids: Vec<String>,

--- a/rust/src/wikidata/translator_tests.rs
+++ b/rust/src/wikidata/translator_tests.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
 use super::{
-    AdminLevel, BatchTranslateOptions, TranslationDataset, TranslationItem, WikidataApi,
-    WikidataCandidateMetadata, WikidataClientOptions, WikidataTranslator,
+    AdminLevel, BatchTranslateOptions, TranslationDataset, TranslationItem, TranslationResult,
+    WikidataApi, WikidataCandidateMetadata, WikidataClientOptions, WikidataTranslator,
 };
 
 #[test]
@@ -57,6 +57,46 @@ fn parse_zhwiki_converted_title_prefers_converted_value() {
     );
 }
 
+#[test]
+fn batch_translate_returns_cached_results_without_network_calls() {
+    let item = TranslationItem::from_values(
+        AdminLevel::Admin1,
+        "서울특별시",
+        "ko",
+        "zh-tw",
+        vec!["KR".to_string()],
+        HashMap::new(),
+    )
+    .unwrap();
+    let dataset =
+        TranslationDataset::new(vec![item.clone()], AdminLevel::Admin1, "ko", "zh-tw", true)
+            .unwrap();
+    let mut translator = WikidataTranslator::with_client(
+        WikidataClientOptions::new("ko", "zh-tw"),
+        PanicApi,
+        None,
+        false,
+    )
+    .unwrap();
+    let cached = TranslationResult {
+        translated: "首爾市".to_string(),
+        qid: Some("Q8684".to_string()),
+        source: "cache".to_string(),
+        used_lang: "zh-tw".to_string(),
+        parent_verified: false,
+    };
+    translator
+        .cache_store
+        .set_translation(&item, &cached, None)
+        .unwrap();
+
+    let results = translator
+        .batch_translate(&dataset, BatchTranslateOptions::default())
+        .unwrap();
+
+    assert_eq!(results.get(&item.id), Some(&cached));
+}
+
 fn test_translator() -> WikidataTranslator<MockApi> {
     WikidataTranslator::with_client(
         WikidataClientOptions::new("ko", "zh-tw"),
@@ -102,5 +142,25 @@ impl WikidataApi for MockApi {
 
     fn zhwiki_convert_title_json(&self, _: &str) -> Result<String, String> {
         Ok(r#"{"query":{"pages":{"1":{"title":"中區"}}}}"#.to_string())
+    }
+}
+
+struct PanicApi;
+
+impl WikidataApi for PanicApi {
+    fn search_entities_json(&self, _: &str, _: usize) -> Result<String, String> {
+        panic!("全 cache hit 不應呼叫 search")
+    }
+
+    fn get_entities_json(&self, _: &[String], _: &str, _: &[String]) -> Result<String, String> {
+        panic!("全 cache hit 不應呼叫 get_entities")
+    }
+
+    fn ask_p131_json(&self, _: &str, _: &str) -> Result<String, String> {
+        panic!("全 cache hit 不應呼叫 P131")
+    }
+
+    fn zhwiki_convert_title_json(&self, _: &str) -> Result<String, String> {
+        panic!("全 cache hit 不應呼叫 zhwiki")
     }
 }

--- a/rust/src/wikidata/translator_tests.rs
+++ b/rust/src/wikidata/translator_tests.rs
@@ -1,0 +1,106 @@
+use std::collections::HashMap;
+
+use super::{
+    AdminLevel, BatchTranslateOptions, TranslationDataset, TranslationItem, WikidataApi,
+    WikidataCandidateMetadata, WikidataClientOptions, WikidataTranslator,
+};
+
+#[test]
+fn batch_translate_filters_candidates_verifies_parent_and_writes_cache() {
+    let item = TranslationItem::from_values(
+        AdminLevel::Admin2,
+        "중구",
+        "ko",
+        "zh-tw",
+        vec!["KR".to_string(), "서울특별시".to_string()],
+        HashMap::new(),
+    )
+    .unwrap();
+    let dataset =
+        TranslationDataset::new(vec![item.clone()], AdminLevel::Admin2, "ko", "zh-tw", true)
+            .unwrap();
+    let mut translator = test_translator();
+    let filter = |_: &str, metadata: &WikidataCandidateMetadata| {
+        !metadata
+            .labels
+            .values()
+            .any(|label| label.to_ascii_lowercase().contains("council"))
+    };
+    let results = translator
+        .batch_translate(
+            &dataset,
+            BatchTranslateOptions {
+                batch_size: 32,
+                parent_qids: HashMap::from([(item.id.clone(), "Q8684".to_string())]),
+                candidate_filter: Some(&filter),
+            },
+        )
+        .unwrap();
+
+    let result = results.get(&item.id).unwrap();
+    assert_eq!(result.translated, "中區");
+    assert_eq!(result.qid.as_deref(), Some("Q2"));
+    assert!(result.parent_verified);
+    assert_eq!(
+        translator.cache_store.get_translation(&item),
+        Some(result.clone())
+    );
+}
+
+#[test]
+fn parse_zhwiki_converted_title_prefers_converted_value() {
+    let body = r#"{"query":{"converted":[{"from":"重庆市","to":"重慶市"}]}}"#;
+
+    assert_eq!(
+        super::translator::parse_zhwiki_converted_title(body).unwrap(),
+        "重慶市"
+    );
+}
+
+fn test_translator() -> WikidataTranslator<MockApi> {
+    WikidataTranslator::with_client(
+        WikidataClientOptions::new("ko", "zh-tw"),
+        MockApi,
+        None,
+        false,
+    )
+    .unwrap()
+}
+
+struct MockApi;
+
+impl WikidataApi for MockApi {
+    fn search_entities_json(&self, _: &str, _: usize) -> Result<String, String> {
+        Ok(r#"{"search":[{"id":"Q1"},{"id":"Q2"}]}"#.to_string())
+    }
+
+    fn get_entities_json(
+        &self,
+        qids: &[String],
+        props: &str,
+        _: &[String],
+    ) -> Result<String, String> {
+        if props == "claims" {
+            return Ok(format!(
+                r#"{{"entities":{{{}}}}}"#,
+                qids.iter()
+                    .map(|qid| format!(r#""{qid}":{{"claims":{{"P31":[]}}}}"#))
+                    .collect::<Vec<_>>()
+                    .join(",")
+            ));
+        }
+        Ok(r#"{"entities":{
+            "Q1":{"labels":{"en":{"value":"Jung District Council"}}},
+            "Q2":{"labels":{"zh-tw":{"value":"中區"},"en":{"value":"Jung District"}}}
+        }}"#
+        .to_string())
+    }
+
+    fn ask_p131_json(&self, candidate_qid: &str, _: &str) -> Result<String, String> {
+        Ok(format!(r#"{{"boolean":{}}}"#, candidate_qid == "Q2"))
+    }
+
+    fn zhwiki_convert_title_json(&self, _: &str) -> Result<String, String> {
+        Ok(r#"{"query":{"pages":{"1":{"title":"中區"}}}}"#.to_string())
+    }
+}

--- a/rust/src/wikidata/translator_tests.rs
+++ b/rust/src/wikidata/translator_tests.rs
@@ -114,12 +114,7 @@ impl WikidataApi for MockApi {
         Ok(r#"{"search":[{"id":"Q1"},{"id":"Q2"}]}"#.to_string())
     }
 
-    fn get_entities_json(
-        &self,
-        qids: &[String],
-        props: &str,
-        _: &[String],
-    ) -> Result<String, String> {
+    fn get_entities_json(&self, qids: &[String], props: &str, _: &str) -> Result<String, String> {
         if props == "claims" {
             return Ok(format!(
                 r#"{{"entities":{{{}}}}}"#,
@@ -152,7 +147,7 @@ impl WikidataApi for PanicApi {
         panic!("全 cache hit 不應呼叫 search")
     }
 
-    fn get_entities_json(&self, _: &[String], _: &str, _: &[String]) -> Result<String, String> {
+    fn get_entities_json(&self, _: &[String], _: &str, _: &str) -> Result<String, String> {
         panic!("全 cache hit 不應呼叫 get_entities")
     }
 

--- a/rust/src/wikidata/types.rs
+++ b/rust/src/wikidata/types.rs
@@ -159,14 +159,17 @@ impl TranslationDatasetBuilder {
         })
     }
 
-    pub fn build_admin1_names(
+    pub fn build_admin1_names<S>(
         &self,
-        names: impl IntoIterator<Item = String>,
-    ) -> Result<TranslationDataset, String> {
+        names: impl IntoIterator<Item = S>,
+    ) -> Result<TranslationDataset, String>
+    where
+        S: AsRef<str>,
+    {
         let mut seen = HashSet::new();
         let mut items = Vec::new();
         for name in names {
-            let name = normalize_text(&name);
+            let name = normalize_text(name.as_ref());
             if name.is_empty() || !seen.insert(name.clone()) {
                 continue;
             }
@@ -188,16 +191,20 @@ impl TranslationDatasetBuilder {
         )
     }
 
-    pub fn build_admin2_pairs(
+    pub fn build_admin2_pairs<P, N>(
         &self,
-        pairs: impl IntoIterator<Item = (String, String)>,
+        pairs: impl IntoIterator<Item = (P, N)>,
         deduplicate: bool,
-    ) -> Result<TranslationDataset, String> {
+    ) -> Result<TranslationDataset, String>
+    where
+        P: AsRef<str>,
+        N: AsRef<str>,
+    {
         let mut seen = HashSet::new();
         let mut items = Vec::new();
         for (parent, name) in pairs {
-            let parent = normalize_text(&parent);
-            let name = normalize_text(&name);
+            let parent = normalize_text(parent.as_ref());
+            let name = normalize_text(name.as_ref());
             if parent.is_empty() || name.is_empty() {
                 continue;
             }

--- a/rust/src/wikidata/types.rs
+++ b/rust/src/wikidata/types.rs
@@ -1,0 +1,268 @@
+use std::collections::{HashMap, HashSet};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AdminLevel {
+    Admin1,
+    Admin2,
+}
+
+impl AdminLevel {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Admin1 => "admin_1",
+            Self::Admin2 => "admin_2",
+        }
+    }
+}
+
+pub fn build_translation_item_id(
+    level: AdminLevel,
+    parent_chain: &[String],
+    original_name: &str,
+) -> String {
+    let mut parts = vec![level.as_str().to_string()];
+    parts.extend(parent_chain.iter().filter(|part| !part.is_empty()).cloned());
+    if !original_name.is_empty() {
+        parts.push(original_name.to_string());
+    }
+    parts.join("/")
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TranslationItem {
+    pub id: String,
+    pub level: AdminLevel,
+    pub original_name: String,
+    pub source_lang: String,
+    pub target_lang: String,
+    pub parent_chain: Vec<String>,
+    pub metadata: HashMap<String, String>,
+}
+
+impl TranslationItem {
+    pub fn from_values(
+        level: AdminLevel,
+        original_name: impl AsRef<str>,
+        source_lang: impl Into<String>,
+        target_lang: impl Into<String>,
+        parent_chain: Vec<String>,
+        metadata: HashMap<String, String>,
+    ) -> Result<Self, String> {
+        let original_name = normalize_text(original_name.as_ref());
+        if original_name.is_empty() {
+            return Err("original_name 不可為空字串".to_string());
+        }
+        let parent_chain = parent_chain
+            .into_iter()
+            .map(|value| normalize_text(&value))
+            .collect::<Vec<_>>();
+        if parent_chain.first().is_none_or(|value| value.is_empty()) {
+            return Err("parent_chain 至少需要包含國家碼".to_string());
+        }
+        let id = build_translation_item_id(level, &parent_chain, &original_name);
+        Ok(Self {
+            id,
+            level,
+            original_name,
+            source_lang: source_lang.into(),
+            target_lang: target_lang.into(),
+            parent_chain,
+            metadata,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TranslationResult {
+    pub translated: String,
+    pub qid: Option<String>,
+    pub source: String,
+    pub used_lang: String,
+    pub parent_verified: bool,
+}
+
+impl TranslationResult {
+    pub fn original(name: &str) -> Self {
+        Self {
+            translated: name.to_string(),
+            qid: None,
+            source: "original".to_string(),
+            used_lang: "original".to_string(),
+            parent_verified: false,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct TranslationDataset {
+    items: Vec<TranslationItem>,
+    pub level: AdminLevel,
+    pub source_lang: String,
+    pub target_lang: String,
+    pub deduplicated: bool,
+}
+
+impl TranslationDataset {
+    pub fn new(
+        items: Vec<TranslationItem>,
+        level: AdminLevel,
+        source_lang: impl Into<String>,
+        target_lang: impl Into<String>,
+        deduplicated: bool,
+    ) -> Result<Self, String> {
+        if items.iter().any(|item| item.level != level) {
+            return Err("所有 TranslationItem 必須擁有相同的 level".to_string());
+        }
+        Ok(Self {
+            items,
+            level,
+            source_lang: source_lang.into(),
+            target_lang: target_lang.into(),
+            deduplicated,
+        })
+    }
+
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    pub fn items(&self) -> &[TranslationItem] {
+        &self.items
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct TranslationDatasetBuilder {
+    country_code: String,
+    source_lang: String,
+    target_lang: String,
+}
+
+impl TranslationDatasetBuilder {
+    pub fn new(
+        country_code: impl AsRef<str>,
+        source_lang: impl Into<String>,
+        target_lang: impl Into<String>,
+    ) -> Result<Self, String> {
+        let country_code = normalize_text(country_code.as_ref());
+        if country_code.is_empty() {
+            return Err("country_code 不可為空".to_string());
+        }
+        Ok(Self {
+            country_code,
+            source_lang: source_lang.into(),
+            target_lang: target_lang.into(),
+        })
+    }
+
+    pub fn build_admin1_names(
+        &self,
+        names: impl IntoIterator<Item = String>,
+    ) -> Result<TranslationDataset, String> {
+        let mut seen = HashSet::new();
+        let mut items = Vec::new();
+        for name in names {
+            let name = normalize_text(&name);
+            if name.is_empty() || !seen.insert(name.clone()) {
+                continue;
+            }
+            items.push(TranslationItem::from_values(
+                AdminLevel::Admin1,
+                name,
+                self.source_lang.clone(),
+                self.target_lang.clone(),
+                vec![self.country_code.clone()],
+                HashMap::new(),
+            )?);
+        }
+        TranslationDataset::new(
+            items,
+            AdminLevel::Admin1,
+            self.source_lang.clone(),
+            self.target_lang.clone(),
+            true,
+        )
+    }
+
+    pub fn build_admin2_pairs(
+        &self,
+        pairs: impl IntoIterator<Item = (String, String)>,
+        deduplicate: bool,
+    ) -> Result<TranslationDataset, String> {
+        let mut seen = HashSet::new();
+        let mut items = Vec::new();
+        for (parent, name) in pairs {
+            let parent = normalize_text(&parent);
+            let name = normalize_text(&name);
+            if parent.is_empty() || name.is_empty() {
+                continue;
+            }
+            let dedupe_key = (parent.clone(), name.clone());
+            if deduplicate && !seen.insert(dedupe_key) {
+                continue;
+            }
+            items.push(TranslationItem::from_values(
+                AdminLevel::Admin2,
+                name,
+                self.source_lang.clone(),
+                self.target_lang.clone(),
+                vec![self.country_code.clone(), parent],
+                HashMap::new(),
+            )?);
+        }
+        TranslationDataset::new(
+            items,
+            AdminLevel::Admin2,
+            self.source_lang.clone(),
+            self.target_lang.clone(),
+            deduplicate,
+        )
+    }
+}
+
+fn normalize_text(value: &str) -> String {
+    value.trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn item_id_includes_level_parent_chain_and_name() {
+        let item = TranslationItem::from_values(
+            AdminLevel::Admin2,
+            "중구",
+            "ko",
+            "zh-tw",
+            vec!["KR".to_string(), "서울특별시".to_string()],
+            HashMap::new(),
+        )
+        .unwrap();
+
+        assert_eq!(item.id, "admin_2/KR/서울특별시/중구");
+    }
+
+    #[test]
+    fn builder_deduplicates_admin2_by_parent_context() {
+        let builder = TranslationDatasetBuilder::new("KR", "ko", "zh-tw").unwrap();
+        let dataset = builder
+            .build_admin2_pairs(
+                [
+                    ("서울특별시".to_string(), "중구".to_string()),
+                    ("부산광역시".to_string(), "중구".to_string()),
+                    ("서울특별시".to_string(), "중구".to_string()),
+                ],
+                true,
+            )
+            .unwrap();
+
+        assert_eq!(dataset.len(), 2);
+        assert_eq!(dataset.items()[0].id, "admin_2/KR/서울특별시/중구");
+        assert_eq!(dataset.items()[1].id, "admin_2/KR/부산광역시/중구");
+    }
+}


### PR DESCRIPTION
## 變更說明

此 PR 修復 KR production extract 的回歸：在沒有 stub 時，流程應恢復使用 Wikidata translator 與既有 cache 產生韓國行政區繁中名稱，而不是退回原語言或缺少翻譯資料。

- 恢復 KR extract 在 production path 使用 KR_wikidata_cache.json 建立 admin1/admin2 翻譯資料。
- 保留 fixture stub 行為，測試資料仍使用 stub，不會觸發 live Wikidata 查詢。
- 補回 Wikidata translator 的 search、labels、P131、P31 與 translation cache 讀寫流程。
- 修復後續熱路徑問題，避免全 cache hit 時仍進行不必要查詢或 cache 改寫。
- 未變更 cache schema version，既有 cache 可直接沿用。

## 測試

- [x] cargo fmt --manifest-path rust/Cargo.toml --check
- [x] cargo clippy --manifest-path rust/Cargo.toml -- -D warnings
- [x] cargo test --manifest-path rust/Cargo.toml
- [x] KR production extract 使用既有 cache 驗證，輸出 3558 rows，admin1/admin2 全 cache hit，fallback=0
- [x] KR extract 輸出 checksum 與 meta_data/kr_geodata.csv 一致：0ca1a89c8a52b9a62e142e8aff0eb3af10b27d602f2fc376f0ed61982a125903
- [x] KR Wikidata cache 與備份 byte-for-byte 一致，驗證全 cache hit 不會改寫 cache

## 檢查清單

- [x] 回歸修復聚焦於 KR extract 與 Wikidata translator/cache 恢復
- [x] 未變更 cache schema version
- [x] 未提交 geoname_data 或 rust/target 產物

## 備註

本地與遠端未找到 dev 分支，因此此 PR 以 main 作為 base。