### PR TITLE
ci(release): 新增 Release Drafter 草稿與 PR 自動標籤

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,219 @@
+# Release Drafter 設定檔
+#
+# 用途：每次 push 到 main 時，自動維護一份「下一版」草稿 release。
+# 草稿內容依 Conventional Commit type 分類，列出所有待發布的 PR。
+#
+# 發版流程定位：
+#   1. 此草稿為中間產物，提供原始 PR 清單供參考。
+#   2. 發版前，維護者手動將草稿內容改寫為 Keep a Changelog 格式
+#      （Added / Changed / Fixed ... + emoji），再貼入正式 release notes。
+#   3. 正式 release 由 .github/workflows/release.yaml 中的
+#      ncipollo/release-action 建立（generateReleaseNotes: false）。
+
+# --------------------------------------------------------------------------
+# 版本號模板
+# --------------------------------------------------------------------------
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+# --------------------------------------------------------------------------
+# Release notes 主體模板
+# --------------------------------------------------------------------------
+template: |
+  # What's Changed
+
+  $CHANGES
+
+  ---
+
+  **完整變更記錄**: [$PREVIOUS_TAG...v$RESOLVED_VERSION](https://github.com/RxChi1d/immich-geodata-zh-tw/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION)
+
+# --------------------------------------------------------------------------
+# PR 變更項目格式
+# --------------------------------------------------------------------------
+# 使用 - $TITLE (#$NUMBER) 格式。change-title-escapes 處理 PR 標題中的
+# 特殊字元：<, *, _, & 會被加上反斜線避免被解讀為 Markdown 格式字元；
+# # 與 @ 則以附加 HTML 註解的方式處理，避免變成 issue 連結或 @mention。
+change-template: '- $TITLE (#$NUMBER)'
+change-title-escapes: '\<*_&#@'
+
+# --------------------------------------------------------------------------
+# 排除不需顯示在 release notes 的 PR
+# --------------------------------------------------------------------------
+exclude-labels:
+  - 'skip-changelog'
+
+# --------------------------------------------------------------------------
+# 分類與版本解析
+# --------------------------------------------------------------------------
+# categories 同時負責：
+#   (1) 將 PR 依 label 分群顯示在草稿中
+#   (2) 透過 type: version-resolver 項目決定下一個版本號的 semver increment
+#
+# Label 命名慣例：
+#   - 'breaking'           ← breaking change（含 ! 的 Conventional Commit）
+#   - 'type: feat'         ← 新功能
+#   - 'type: fix'          ← 修復
+#   - 'type: perf'         ← 效能改善
+#   - 'type: refactor'     ← 重構
+#   - 'type: docs'         ← 文件
+#   - 'type: test'         ← 測試
+#   - 'type: build'        ← 建置相關
+#   - 'type: ci'           ← CI/CD 相關
+#   - 'type: chore'        ← 雜項維護（含 style、revert）
+#   - 'skip-changelog'     ← 不顯示於 release notes
+
+#
+# exclusive: true 說明：
+#   release-drafter 預設允許同一 PR 同時落入多個同型別類別，導致 breaking
+#   PR（同時帶 'breaking' 與 'type: feat'/'type: fix' 等 label）會在
+#   Breaking Changes 與對應 feat/fix 區塊「重複列出」。為每個渲染類別加上
+#   exclusive: true 後，PR 只會落入「由上而下第一個匹配」的類別；因此
+#   Breaking Changes 置於最前，breaking PR 只會出現在該區塊一次。
+categories:
+  # --- Breaking Changes（major bump）---
+  - title: '⚠️ Breaking Changes'
+    semver-increment: major
+    exclusive: true
+    when:
+      labels:
+        - 'breaking'
+
+  # --- 新功能（minor bump）---
+  - title: '🚀 feat'
+    semver-increment: minor
+    exclusive: true
+    when:
+      labels:
+        - 'type: feat'
+
+  # --- 修復（patch bump）---
+  - title: '🐛 fix'
+    semver-increment: patch
+    exclusive: true
+    when:
+      labels:
+        - 'type: fix'
+
+  # --- 效能改善（patch bump）---
+  - title: '⚡ perf'
+    semver-increment: patch
+    exclusive: true
+    when:
+      labels:
+        - 'type: perf'
+
+  # --- 重構（patch bump）---
+  - title: '♻️ refactor'
+    semver-increment: patch
+    exclusive: true
+    when:
+      labels:
+        - 'type: refactor'
+
+  # --- 文件（patch bump）---
+  - title: '📝 docs'
+    semver-increment: patch
+    exclusive: true
+    when:
+      labels:
+        - 'type: docs'
+
+  # --- 測試（patch bump）---
+  - title: '🧪 test'
+    semver-increment: patch
+    exclusive: true
+    when:
+      labels:
+        - 'type: test'
+
+  # --- 建置 / CI / 雜項（patch bump）---
+  - title: '🔧 build / ci / chore'
+    semver-increment: patch
+    exclusive: true
+    when:
+      labels:
+        - 'type: build'
+        - 'type: ci'
+        - 'type: chore'
+
+  # --- 其他變更（未分類）---
+  # catch-all 收容區：省略 when，type 預設為 changelog。
+  # Reason: release-drafter 只有在存在「省略 when 的 changelog 類別」時，
+  #   無 label（autolabeler 漏接）的 PR 才會出現在草稿中；否則該 PR 會被
+  #   完全省略、靜默消失，導致維護者改寫 Keep a Changelog 時漏列變更。
+  #   此類別作為最低防線，讓漏接 PR 仍可見並供手動歸類。
+  #   不設 exclusive，但因排在所有具名類別之後，已被歸類的 PR 不會落入此區。
+  - title: '📦 其他變更（未分類）'
+
+  # --- 版本解析 fallback（無符合 label 時預設 patch）---
+  # type: version-resolver 項目不渲染 changelog 區塊，僅參與版本計算。
+  # 此項省略 when 條件，因此匹配「所有」PR，保證 $RESOLVED_VERSION 至少有
+  # patch 級別的 increment；最終版本取所有匹配項中最高的 increment
+  # （例如同時匹配 Breaking Changes 的 major 時，以 major 為準）。
+  - type: version-resolver
+    semver-increment: patch
+
+# --------------------------------------------------------------------------
+# Autolabeler：依 PR 標題自動上 label
+# --------------------------------------------------------------------------
+# regex 格式：/pattern/flags，flags i = 大小寫不敏感。
+# 各 type 允許：可選 scope（括號）、可選 breaking ! 符號。
+# breaking ! 額外觸發 'breaking' label（由專屬規則處理）。
+#
+# 冒號後空白以 \s? 表示（0 或 1 個空白）：
+#   Conventional Commits 規範要求冒號後有空白，但人工或自動產生的標題常
+#   漏打空白（如 'feat:沒有空白'）。放寬為 \s? 可容忍此情況，避免該類 PR
+#   掉出所有分類；即便如此，catch-all 類別仍是最低防線。
+autolabeler:
+  # Breaking change：標題含 type(scope)?!: 格式
+  - label: 'breaking'
+    title:
+      - '/^(feat|fix|perf|refactor|docs|test|build|ci|chore|style|revert)(\(.+\))?!:/i'
+
+  # feat
+  - label: 'type: feat'
+    title:
+      - '/^feat(\(.+\))?(!)?:\s?/i'
+
+  # fix
+  - label: 'type: fix'
+    title:
+      - '/^fix(\(.+\))?(!)?:\s?/i'
+
+  # perf
+  - label: 'type: perf'
+    title:
+      - '/^perf(\(.+\))?(!)?:\s?/i'
+
+  # refactor
+  - label: 'type: refactor'
+    title:
+      - '/^refactor(\(.+\))?(!)?:\s?/i'
+
+  # docs
+  - label: 'type: docs'
+    title:
+      - '/^docs(\(.+\))?(!)?:\s?/i'
+
+  # test
+  - label: 'type: test'
+    title:
+      - '/^test(\(.+\))?(!)?:\s?/i'
+
+  # build
+  - label: 'type: build'
+    title:
+      - '/^build(\(.+\))?(!)?:\s?/i'
+
+  # ci
+  - label: 'type: ci'
+    title:
+      - '/^ci(\(.+\))?(!)?:\s?/i'
+
+  # chore（含 style、revert 合併至此分類）
+  - label: 'type: chore'
+    title:
+      - '/^chore(\(.+\))?(!)?:\s?/i'
+      - '/^style(\(.+\))?(!)?:\s?/i'
+      - '/^revert(\(.+\))?(!)?:\s?/i'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -8,7 +8,12 @@
 #   2. 發版前，維護者手動將草稿內容改寫為 Keep a Changelog 格式
 #      （Added / Changed / Fixed ... + emoji），再貼入正式 release notes。
 #   3. 正式 release 由 .github/workflows/release.yaml 中的
-#      ncipollo/release-action 建立（generateReleaseNotes: false）。
+#      ncipollo/release-action 建立（推送同名 tag 時接管此草稿並轉正）。
+#
+# 語法依據：release-drafter v7 的 runtime 驗證 schema
+# （src/actions/drafter/config/schemas/config.schema.ts）。
+# 注意 repo master 上的 schema.json 是未發布的開發版語法
+# （when/exclusive/semver-increment），v7 並不支援，勿混用。
 
 # --------------------------------------------------------------------------
 # 版本號模板
@@ -44,11 +49,9 @@ exclude-labels:
   - 'skip-changelog'
 
 # --------------------------------------------------------------------------
-# 分類與版本解析
+# 分類
 # --------------------------------------------------------------------------
-# categories 同時負責：
-#   (1) 將 PR 依 label 分群顯示在草稿中
-#   (2) 透過 type: version-resolver 項目決定下一個版本號的 semver increment
+# 依 label 將 PR 分群顯示在草稿中。
 #
 # Label 命名慣例：
 #   - 'breaking'           ← breaking change（含 ! 的 Conventional Commit）
@@ -62,109 +65,75 @@ exclude-labels:
 #   - 'type: ci'           ← CI/CD 相關
 #   - 'type: chore'        ← 雜項維護（含 style、revert）
 #   - 'skip-changelog'     ← 不顯示於 release notes
-
 #
-# exclusive: true 說明：
-#   release-drafter 預設允許同一 PR 同時落入多個同型別類別，導致 breaking
-#   PR（同時帶 'breaking' 與 'type: feat'/'type: fix' 等 label）會在
-#   Breaking Changes 與對應 feat/fix 區塊「重複列出」。為每個渲染類別加上
-#   exclusive: true 後，PR 只會落入「由上而下第一個匹配」的類別；因此
-#   Breaking Changes 置於最前，breaking PR 只會出現在該區塊一次。
+# 重複列出的防範：v7 會把 PR「刻意 duplicate」到所有匹配的分類，因此
+# autolabeler 的 type regex 不匹配含 ! 的標題（見下方 autolabeler 區），
+# 讓 breaking PR 只獲得 'breaking' 一個 label、只出現在 Breaking Changes 區。
 categories:
-  # --- Breaking Changes（major bump）---
   - title: '⚠️ Breaking Changes'
-    semver-increment: major
-    exclusive: true
-    when:
-      labels:
-        - 'breaking'
+    labels:
+      - 'breaking'
 
-  # --- 新功能（minor bump）---
   - title: '🚀 feat'
-    semver-increment: minor
-    exclusive: true
-    when:
-      labels:
-        - 'type: feat'
+    labels:
+      - 'type: feat'
 
-  # --- 修復（patch bump）---
   - title: '🐛 fix'
-    semver-increment: patch
-    exclusive: true
-    when:
-      labels:
-        - 'type: fix'
+    labels:
+      - 'type: fix'
 
-  # --- 效能改善（patch bump）---
   - title: '⚡ perf'
-    semver-increment: patch
-    exclusive: true
-    when:
-      labels:
-        - 'type: perf'
+    labels:
+      - 'type: perf'
 
-  # --- 重構（patch bump）---
   - title: '♻️ refactor'
-    semver-increment: patch
-    exclusive: true
-    when:
-      labels:
-        - 'type: refactor'
+    labels:
+      - 'type: refactor'
 
-  # --- 文件（patch bump）---
   - title: '📝 docs'
-    semver-increment: patch
-    exclusive: true
-    when:
-      labels:
-        - 'type: docs'
+    labels:
+      - 'type: docs'
 
-  # --- 測試（patch bump）---
   - title: '🧪 test'
-    semver-increment: patch
-    exclusive: true
-    when:
-      labels:
-        - 'type: test'
+    labels:
+      - 'type: test'
 
-  # --- 建置 / CI / 雜項（patch bump）---
   - title: '🔧 build / ci / chore'
-    semver-increment: patch
-    exclusive: true
-    when:
-      labels:
-        - 'type: build'
-        - 'type: ci'
-        - 'type: chore'
+    labels:
+      - 'type: build'
+      - 'type: ci'
+      - 'type: chore'
 
-  # --- 其他變更（未分類）---
-  # catch-all 收容區：省略 when，type 預設為 changelog。
-  # Reason: release-drafter 只有在存在「省略 when 的 changelog 類別」時，
-  #   無 label（autolabeler 漏接）的 PR 才會出現在草稿中；否則該 PR 會被
-  #   完全省略、靜默消失，導致維護者改寫 Keep a Changelog 時漏列變更。
-  #   此類別作為最低防線，讓漏接 PR 仍可見並供手動歸類。
-  #   不設 exclusive，但因排在所有具名類別之後，已被歸類的 PR 不會落入此區。
+  # catch-all 收容區：不設 labels 的分類即為官方的「未分類」收容區
+  # （categorize-pull-requests.ts 以 labels 為空的分類承接無匹配 label 的
+  # PR）。autolabeler 漏接的 PR（非 conventional 標題等）會落入此區，
+  # 讓維護者改寫 Keep a Changelog 時看得見並手動歸類，而非靜默消失。
   - title: '📦 其他變更（未分類）'
 
-  # --- 版本解析 fallback（無符合 label 時預設 patch）---
-  # type: version-resolver 項目不渲染 changelog 區塊，僅參與版本計算。
-  # 此項省略 when 條件，因此匹配「所有」PR，保證 $RESOLVED_VERSION 至少有
-  # patch 級別的 increment；最終版本取所有匹配項中最高的 increment
-  # （例如同時匹配 Breaking Changes 的 major 時，以 major 為準）。
-  - type: version-resolver
-    semver-increment: patch
+# --------------------------------------------------------------------------
+# 版本解析
+# --------------------------------------------------------------------------
+# 依 label 決定 $RESOLVED_VERSION 的 semver increment：
+#   breaking → major、feat → minor、其餘（含無 label）→ patch（default）。
+version-resolver:
+  major:
+    labels:
+      - 'breaking'
+  minor:
+    labels:
+      - 'type: feat'
+  default: patch
 
 # --------------------------------------------------------------------------
 # Autolabeler：依 PR 標題自動上 label
 # --------------------------------------------------------------------------
 # regex 格式：/pattern/flags，flags i = 大小寫不敏感。
-# 各 type 允許：可選 scope（括號）、可選 breaking ! 符號。
-# breaking ! 額外觸發 'breaking' label（由專屬規則處理）。
+# 各 type 允許可選 scope（括號）；冒號後空白以 \s? 表示（0 或 1 個空白），
+# 容忍漏打空白的標題（如 'feat:沒有空白'），避免該類 PR 掉出分類。
 #
-# 冒號後空白以 \s? 表示（0 或 1 個空白）：
-#   Conventional Commits 規範要求冒號後有空白，但人工或自動產生的標題常
-#   漏打空白（如 'feat:沒有空白'）。放寬為 \s? 可容忍此情況，避免該類 PR
-#   掉出所有分類；即便如此，catch-all 類別仍是最低防線。
+# breaking 的處理：含 ! 的標題（type(scope)!:）只由 breaking 規則匹配；
+# type 規則刻意「不」匹配 !（regex 中沒有 (!)?），避免 breaking PR 同時
+# 獲得 type label 而在草稿中重複列出（v7 分類無去重機制）。
 autolabeler:
   # Breaking change：標題含 type(scope)?!: 格式
   - label: 'breaking'
@@ -174,46 +143,46 @@ autolabeler:
   # feat
   - label: 'type: feat'
     title:
-      - '/^feat(\(.+\))?(!)?:\s?/i'
+      - '/^feat(\(.+\))?:\s?/i'
 
   # fix
   - label: 'type: fix'
     title:
-      - '/^fix(\(.+\))?(!)?:\s?/i'
+      - '/^fix(\(.+\))?:\s?/i'
 
   # perf
   - label: 'type: perf'
     title:
-      - '/^perf(\(.+\))?(!)?:\s?/i'
+      - '/^perf(\(.+\))?:\s?/i'
 
   # refactor
   - label: 'type: refactor'
     title:
-      - '/^refactor(\(.+\))?(!)?:\s?/i'
+      - '/^refactor(\(.+\))?:\s?/i'
 
   # docs
   - label: 'type: docs'
     title:
-      - '/^docs(\(.+\))?(!)?:\s?/i'
+      - '/^docs(\(.+\))?:\s?/i'
 
   # test
   - label: 'type: test'
     title:
-      - '/^test(\(.+\))?(!)?:\s?/i'
+      - '/^test(\(.+\))?:\s?/i'
 
   # build
   - label: 'type: build'
     title:
-      - '/^build(\(.+\))?(!)?:\s?/i'
+      - '/^build(\(.+\))?:\s?/i'
 
   # ci
   - label: 'type: ci'
     title:
-      - '/^ci(\(.+\))?(!)?:\s?/i'
+      - '/^ci(\(.+\))?:\s?/i'
 
   # chore（含 style、revert 合併至此分類）
   - label: 'type: chore'
     title:
-      - '/^chore(\(.+\))?(!)?:\s?/i'
-      - '/^style(\(.+\))?(!)?:\s?/i'
-      - '/^revert(\(.+\))?(!)?:\s?/i'
+      - '/^chore(\(.+\))?:\s?/i'
+      - '/^style(\(.+\))?:\s?/i'
+      - '/^revert(\(.+\))?:\s?/i'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -134,6 +134,10 @@ version-resolver:
 # breaking 的處理：含 ! 的標題（type(scope)!:）只由 breaking 規則匹配；
 # type 規則刻意「不」匹配 !（regex 中沒有 (!)?），避免 breaking PR 同時
 # 獲得 type label 而在草稿中重複列出（v7 分類無去重機制）。
+#
+# 注意：autolabeler 只會「新增」label，不會移除過時的 label。若 PR 改過
+# 標題（例如 feat: → feat!:），舊 label（type: feat）會殘留並導致草稿
+# 重複列出，需由維護者手動移除。
 autolabeler:
   # Breaking change：標題含 type(scope)?!: 格式
   - label: 'breaking'

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -12,7 +12,6 @@ on:
   push:
     branches:
       - main
-      - ci/release-drafter  # 臨時：合併前實測草稿生成，驗證後移除
   pull_request_target:
     types:
       - opened

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,0 +1,61 @@
+name: Release Drafter
+
+# --------------------------------------------------------------------------
+# 觸發條件
+# --------------------------------------------------------------------------
+# push to main：更新下一版草稿 release（包含已合併 PR 的變更清單）。
+# pull_request_target：對 PR（含 fork）自動上 label，讓草稿分類正確。
+#   - edited 事件：PR 標題修改後重新觸發 autolabeler，確保 label 與標題一致。
+#   - 使用 pull_request_target 而非 pull_request，使 fork PR 也能被上 label
+#     （pull_request_target 具備寫入 token 權限，故 job 內絕不執行 PR 程式碼）。
+on:
+  push:
+    branches:
+      - main
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited  # PR 標題修改後重新上 label
+
+# --------------------------------------------------------------------------
+# 頂層預設權限（最小化原則）
+# --------------------------------------------------------------------------
+permissions:
+  contents: read
+
+jobs:
+  # --------------------------------------------------------------------------
+  # 更新草稿 release（push to main 時執行）
+  # --------------------------------------------------------------------------
+  release-drafter:
+    # 僅在 push to main 時更新草稿；PR 事件跳過此 job
+    if: github.event_name == 'push'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write       # 建立與更新 draft release 所需
+      pull-requests: read   # 讀取 PR metadata 以生成變更清單
+    steps:
+      - name: 更新草稿 Release
+        uses: release-drafter/release-drafter@v7
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+  # --------------------------------------------------------------------------
+  # 自動上 label（PR 事件時執行）
+  # --------------------------------------------------------------------------
+  autolabeler:
+    # 僅在 pull_request_target 事件時上 label；push 事件跳過此 job
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-24.04
+    permissions:
+      # pull_request_target 具備寫入 token 權限，此 job 僅操作 PR label，
+      # 嚴格限制權限範圍；contents 保持 read 以降低供應鏈攻擊風險。
+      contents: read
+      pull-requests: write  # 對 PR 新增 label 所需
+    steps:
+      - name: 自動上 label
+        uses: release-drafter/release-drafter/autolabeler@v7
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -12,6 +12,7 @@ on:
   push:
     branches:
       - main
+      - ci/release-drafter  # 臨時：合併前實測草稿生成，驗證後移除
   pull_request_target:
     types:
       - opened

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -128,6 +128,14 @@ jobs:
           generateReleaseNotes: false
           commit: main
           tag: ${{ env.VERSION_TAG }}
+          # Release Drafter 草稿接管：
+          #   release-drafter 每次 push main 會以同名 tag（vX.Y.Z）維護一份
+          #   草稿 release。啟用 allowUpdates 讓正式發布接管既有草稿並轉正
+          #   （上方 draft: false 在更新時生效），artifacts 附加至同一 release。
+          #   omitBodyDuringUpdate 保留草稿中已手動改寫的 release notes，
+          #   避免被空 body 覆寫。無同名草稿時照常建立新 release。
+          allowUpdates: true
+          omitBodyDuringUpdate: true
           # 僅穩定版本標記為 latest；含預發布標識（a/b/rc/alpha/beta）的標記為 prerelease
           makeLatest: ${{ !contains(env.VERSION_TAG, 'a') && !contains(env.VERSION_TAG, 'b') && !contains(env.VERSION_TAG, 'rc') && !contains(env.VERSION_TAG, 'alpha') && !contains(env.VERSION_TAG, 'beta') }}
           prerelease: ${{ contains(env.VERSION_TAG, 'a') || contains(env.VERSION_TAG, 'b') || contains(env.VERSION_TAG, 'rc') || contains(env.VERSION_TAG, 'alpha') || contains(env.VERSION_TAG, 'beta') }}


### PR DESCRIPTION
## 變更說明

補上 CLAUDE.md 已記載但 repo 中實際缺失的 Release Drafter 設定，建立「conventional 草稿 → 手動改寫 Keep a Changelog → 發佈」的 release notes 工作流程。

### 新增

- **`.github/release-drafter.yml`**（release-drafter v7 經典語法：categories `title`+`labels`、頂層 `version-resolver`）
  - 依 Conventional Commit type 分類草稿（⚠️ Breaking / 🚀 feat / 🐛 fix / ⚡ perf / ♻️ refactor / 📝 docs / 🧪 test / 🔧 build·ci·chore）
  - catch-all「📦 其他變更（未分類）」區（無 labels 的分類）：autolabeler 漏接的 PR 仍會顯示，不會靜默消失
  - 防重複列出：v7 會將 PR duplicate 到所有匹配分類，因此 type regex 不匹配含 `!` 的標題，breaking PR 只獲得 `breaking` label、只出現在 Breaking Changes 區
  - 版本解析：`breaking` → major、`type: feat` → minor、其餘 fallback patch
  - autolabeler：依 PR 標題正則自動上 `type: *` label，容忍冒號後缺空白
- **`.github/workflows/release-drafter.yaml`**
  - push main → 更新草稿；`pull_request_target`（含 `edited`）→ 自動上 label
  - 權限逐 job 最小化；autolabeler job 不 checkout PR 程式碼

### 修改

- **`.github/workflows/release.yaml`**：`ncipollo/release-action` 啟用 `allowUpdates: true` + `omitBodyDuringUpdate: true`。推送同名 tag 時接管 Release Drafter 草稿並轉正發佈（artifacts 附加至同一 release、保留手動改寫的 notes），解決草稿佔用 tag 造成的發布衝突。

### 重要：v7 語法勘誤

初版設定誤用 release-drafter repo master 上的 `schema.json` 語法（`when`/`exclusive`/`semver-increment`/`type: version-resolver`）——那是**未發布的開發版**。v7 runtime（zod）驗證失敗後，已依 v7 原始碼（`config.schema.ts`、`categorize-pull-requests.ts`）改寫為經典語法並實測通過。

### 發版流程（合併後）

1. PR 合併至 main → 草稿自動累積 conventional 分類的變更清單
2. 發版前在 GitHub 上手動將草稿改寫為 Keep a Changelog 格式
3. 推 tag → release 流程接管草稿、附上 artifacts 並發佈

## 測試

### 合併前實測（在本分支上以臨時觸發執行真實 workflow，測畢已清理）

- [x] **草稿生成**：分支 push 觸發 drafter，成功產生草稿 `v2.2.5`——模板結構、compare 連結正確；無 label 的既往 PR（#42–#44）落入 catch-all 區未消失；版本解析 default patch 正確
- [x] **autolabeler**：測試 PR（#47）標題 `feat:` 自動獲得 `type: feat`；改標題為 `feat!:`（`edited` 事件）自動加上 `breaking`
- [x] 測試物已全部清除（測試 PR、測試分支、測試草稿、臨時觸發）

### 靜態驗證

- [x] 三個 YAML 檔案語法驗證通過
- [x] 設定欄位對照 v7 runtime zod schema（`config.schema.ts`）逐一驗證
- [x] autolabeler regex 以近期 10 個真實 PR 標題（含中文 description 與 scope）實測 10/10 正確，含 breaking、缺空白、非 conventional 等邊界案例
- [x] 草稿接管行為以 `ncipollo/release-action` 原始碼驗證（`findMatchingDraftReleaseId` 以 `tag_name` 比對 draft；`omitBodyDuringUpdate` 保留草稿 body；`draft: false` 於更新時轉正）
- [x] 11 個 labels（`breaking`、`type: *`、`skip-changelog`）已預先建立（含顏色與描述）

### 合併後待驗證（風險極低）

- [ ] `pull_request_target` 觸發語義（官方限制：只執行 default branch 上的 workflow，合併前無法實測；autolabeler action 本身已透過 `pull_request` 事件完整驗證）
- [ ] 下次發版時的草稿接管

## 檢查清單

- [x] 遵循 Conventional Commits 與專案 commit 規範
- [x] YAML 註解使用 zh-tw
- [x] 與既有 workflow 風格一致（`runs-on: ubuntu-24.04`、`.yaml` 副檔名）
- [x] 權限最小化（`pull_request_target` job 僅 `pull-requests: write`，不執行 PR 程式碼）

## 已知限制

- 草稿 tag 為 release-drafter 推算的下一版；若實際推的 tag 與草稿不同（例如手動跳版），會建立新 release，舊草稿需手動刪除。
- autolabeler 只增不減 label：PR 改標題後殘留的舊 label 需手動移除（已註解於設定檔）。
- 合併前測試產生的草稿已刪除；合併後首次 push main 會重新生成（既往無 label 的 PR 會列在未分類區，屬預期行為）。