### PR TITLE
fix(ci): 修正預發布 fallback notes 的指引與 compare 連結

### DIFF
--- a/.github/scripts/extract-release-notes.sh
+++ b/.github/scripts/extract-release-notes.sh
@@ -58,7 +58,10 @@ fi
 compare_url="$(grep -m1 "^\[${version}\]: " "${changelog}" | sed 's/^[^ ]* //' || true)"
 if [[ -z "${compare_url}" ]]; then
   repo_url="https://github.com/${GITHUB_REPOSITORY:-RxChi1d/immich-geodata-zh-tw}"
-  prev_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+  # Reason: 在 tag checkout 上 git describe 會回傳 tag 自身，需改查 tag^
+  # 取得「前一個」tag；tag 尚不存在時（workflow_dispatch）退回查 HEAD。
+  prev_tag="$(git describe --tags --abbrev=0 "${version_tag}^" 2>/dev/null \
+    || git describe --tags --abbrev=0 2>/dev/null || true)"
   if [[ -n "${prev_tag}" && "${prev_tag}" != "${version_tag}" ]]; then
     compare_url="${repo_url}/compare/${prev_tag}...${version_tag}"
   else
@@ -84,10 +87,18 @@ if [[ -z "${section//[[:space:]]/}" ]]; then
     echo "正式發版前請先完成 CHANGELOG 版本切割（[未發佈版本] → [${version}]）。" >&2
     exit 1
   fi
-  # 預發布版缺區段：輸出簡化說明
+  # 預發布版缺區段：輸出簡化說明。
+  # 指引目標依 CHANGELOG 狀態而定：若對應正式版的區段已切割（如先切
+  # [3.0.0] 再發 v3.0.0rc1），指向該區段；否則指向 [未發佈版本]。
+  base_version="$(sed -E 's/(a|b|rc)[0-9]+$//' <<< "${version}")"
+  if grep -q "^## \[${base_version}\]" "${changelog}"; then
+    section_hint="「${base_version}」"
+  else
+    section_hint="「未發佈版本」"
+  fi
   body="預發布版本（\`${version_tag}\`），用於正式發布前的驗證；完整變更說明將隨對應的正式版本發布。
 
-詳細變更請參考 [CHANGELOG](https://github.com/${GITHUB_REPOSITORY:-RxChi1d/immich-geodata-zh-tw}/blob/main/CHANGELOG.md) 的「未發佈版本」區段。"
+詳細變更請參考 [CHANGELOG](https://github.com/${GITHUB_REPOSITORY:-RxChi1d/immich-geodata-zh-tw}/blob/main/CHANGELOG.md) 的 ${section_hint} 區段。"
 else
   # 分類標題轉換為 Release Notes 的 emoji 格式（對應表見 CLAUDE.md）
   body="$(sed \


### PR DESCRIPTION
## 變更說明

v3.0.0rc1 實際發布（fallback 路徑首次真實執行）發現兩個外觀問題，本 PR 修正：

1. **CHANGELOG 指引失準**：fallback 文字固定指向「未發佈版本」區段，但「先切版、後發 rc」的流程中該區段已切空。改為：對應正式版區段（去除 `aN/bN/rcN` 後綴）存在時指向該區段（如 `[3.0.0]`），否則維持指向「未發佈版本」。
2. **compare 連結退化**：CI 在 tag checkout 上 `git describe` 回傳 tag 自身，導致連結退化為 `commits/v3.0.0rc1`。改為先查 `tag^` 取得前一個 tag（正確產出 `v2.2.4...v3.0.0rc1`），tag 尚不存在時（workflow_dispatch 預演）退回查 HEAD。

## 變更類型

- [x] 錯誤修復（fix）

## 測試

- [x] `v3.0.0rc1`（本地有 tag、CHANGELOG 已切 `[3.0.0]`）：指引顯示「3.0.0」區段、compare 連結 `v2.2.4...v3.0.0rc1` ✓
- [x] `v9.9.9rc1`（無對應正式版區段）：指引維持「未發佈版本」✓
- [x] 回歸：`v3.0.0`／`v2.2.4`（正常區段抽取）、`v9.9.9`（正式版缺區段失敗）行為不變 ✓
- [ ] Rust gates：不適用（純 shell script 變更）

## 檢查清單

- [x] PR 標題遵循 Conventional Commits 格式
- [x] Commit 訊息遵循專案規範（zh-tw、Google 風格）
- [ ] 面向使用者的變更已記錄於 CHANGELOG.md（不適用：維護者導向 CI 修正）
- [x] 未包含不應提交的檔案