### PR TITLE
docs: 補充加速器在 Homebrew services 下的重啟方式

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@
 
 ## [未發佈版本]
 
+### Changed
+- **非容器部署說明**：補充 Homebrew services 環境下的重啟方式（`immich-accelerator stop` 會因 `KeepAlive` 立即被 launchd 拉回，隨後的 `start` 會因連接埠被佔用而失敗），並說明分離式部署下 Docker 端設定 `IMMICH_WORKERS_INCLUDE=api` 後可自 `entrypoint` 移除更新指令。
+
 ### Security
 - **相依套件安全性更新**：將 `quinn-proto` 更新至 0.11.17，解除 GHSA 對 QUIC 亂序封包重組可造成記憶體耗盡的警示。該套件為 `reqwest` 的選用相依，本專案未啟用 HTTP/3，實際上未編譯進產物，因此無使用者可感知的行為變更。
 

--- a/README.en.md
+++ b/README.en.md
@@ -220,7 +220,7 @@ This project supports the following two deployment methods:
 
 Steps for a split deployment:
 
-1. **Check the install locations.** The accelerator creates a synthetic link for `/build`, so the geodata path matches the container and needs no extra configuration.
+1. **Check the install locations.** The accelerator creates a synthetic link for `/build`, so the geodata path matches the container and needs no extra configuration. `i18n-iso-countries` lives under a server directory named after the Immich version, so confirm that the version in the output matches the Immich you are running.
 
    ```bash
    bash <(curl -sSL https://github.com/RxChi1d/immich-geodata-zh-tw/releases/latest/download/update_data.sh) --print-paths
@@ -234,7 +234,13 @@ Steps for a split deployment:
    bash <(curl -sSL https://github.com/RxChi1d/immich-geodata-zh-tw/releases/latest/download/update_data.sh) --install
    ```
 
-3. **Restart the worker** so Immich re-imports the geographic data.
+3. **Restart the worker** so Immich re-imports the geographic data. Under Homebrew services, you must use `brew services restart`:
+
+   ```bash
+   brew services restart immich-accelerator
+   ```
+
+   Without Homebrew services, use:
 
    ```bash
    immich-accelerator stop && immich-accelerator start
@@ -244,7 +250,8 @@ Steps for a split deployment:
 
 > [!NOTE]
 > - Immich compares `geodata-date.txt` with the record in its database and only re-imports when they differ, so restarting alone does not trigger a redundant import.
-> - If the Docker side still runs a microservices worker, both hosts attempt the import and will overwrite each other when their data versions differ. For split deployments, set `IMMICH_WORKERS_INCLUDE=api` on the Docker side.
+> - If the Docker side still runs a microservices worker, both hosts attempt the import and will overwrite each other when their data versions differ. For split deployments, set `IMMICH_WORKERS_INCLUDE=api` on the Docker side; once it is set that host never reads the geographic data, so the update command can also be removed from its `entrypoint` to avoid downloading the release on every start.
+> - Under Homebrew services, `immich-accelerator stop` lets launchd restart the services immediately because of `KeepAlive`, and the following `start` then fails because the port is already in use. Use `brew services restart` instead.
 
 Unlike the container, the accelerator's data is persistent: `stop` / `start` and rebooting never require a reinstall. Only `immich-accelerator update`, which switches the Immich version, does — see [Update Geographic Data](#macos-native-worker-and-other-non-container-deployments).
 
@@ -380,22 +387,18 @@ To update:
    bash <(curl -sSL https://github.com/RxChi1d/immich-geodata-zh-tw/releases/latest/download/update_data.sh) --install
    ```
 
-2. Restart the worker.
-
-   ```bash
-   immich-accelerator stop && immich-accelerator start
-   ```
+2. Restart the worker. Under Homebrew services run `brew services restart immich-accelerator`; otherwise run `immich-accelerator stop && immich-accelerator start`.
 
 3. Run **Extract Metadata** in Immich.
 
-If you would rather not have to remember the version-switch case, replace `immich-accelerator start` with a small wrapper, which behaves like the container's `entrypoint`:
+The steps above can be combined into one script, to be run whenever an update is needed:
 
 ```bash
 #!/bin/bash
-# ~/.local/bin/immich-start
+# ~/.local/bin/immich-geodata-update
 set -e
 bash <(curl -sSL https://github.com/RxChi1d/immich-geodata-zh-tw/releases/latest/download/update_data.sh) --install
-immich-accelerator start
+brew services restart immich-accelerator
 ```
 
 The install itself is idempotent, so re-running it when the data is already current has no side effects.

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@
 
 分離式部署的安裝步驟：
 
-1. **確認安裝位置**（加速器會建立 `/build` 的 synthetic link，因此 geodata 路徑與容器一致，不需要額外設定）
+1. **確認安裝位置**。加速器會建立 `/build` 的 synthetic link，因此 geodata 路徑與容器一致，不需要額外設定；`i18n-iso-countries` 則位於依 Immich 版本區分的 server 目錄下，先確認輸出的版本與目前執行的 Immich 相符。
 
    ```bash
    bash <(curl -sSL https://github.com/RxChi1d/immich-geodata-zh-tw/releases/latest/download/update_data.sh) --print-paths
@@ -229,7 +229,13 @@
    bash <(curl -sSL https://github.com/RxChi1d/immich-geodata-zh-tw/releases/latest/download/update_data.sh) --install
    ```
 
-3. **重啟 worker**，讓 Immich 重新匯入地理資料
+3. **重啟 worker**，讓 Immich 重新匯入地理資料。以 Homebrew services 管理時，必須使用 `brew services restart`：
+
+   ```bash
+   brew services restart immich-accelerator
+   ```
+
+   未使用 Homebrew services 時，改用：
 
    ```bash
    immich-accelerator stop && immich-accelerator start
@@ -239,7 +245,8 @@
 
 > [!NOTE]
 > - Immich 會比對 `geodata-date.txt` 與資料庫中的紀錄，只有不同時才會重新匯入，重啟本身不會造成重複匯入。
-> - Docker 端若仍在執行 microservices worker，兩台都會嘗試匯入，資料版本不一致時會互相覆蓋。分離式部署建議在 Docker 端設定 `IMMICH_WORKERS_INCLUDE=api`。
+> - Docker 端若仍在執行 microservices worker，兩台都會嘗試匯入，資料版本不一致時會互相覆蓋。分離式部署建議在 Docker 端設定 `IMMICH_WORKERS_INCLUDE=api`；設定後該端不會讀取地理資料，可一併從其 `entrypoint` 移除更新指令，避免每次啟動重複下載。
+> - 以 Homebrew services 管理時，`immich-accelerator stop` 會觸發 launchd 依 `KeepAlive` 立即重啟服務，隨後的 `start` 會因連接埠已被佔用而失敗。請改用 `brew services restart`。
 
 與容器不同，加速器的資料是持久的：`stop` / `start` 或重新開機都不需要重新安裝。只有在 `immich-accelerator update` 切換 Immich 版本時才需要，詳見[更新地理資料](#macos-原生-worker-與其他非容器部署)。
 
@@ -375,22 +382,18 @@ bash update_data.sh --install --archive /path/to/release.tar.gz
    bash <(curl -sSL https://github.com/RxChi1d/immich-geodata-zh-tw/releases/latest/download/update_data.sh) --install
    ```
 
-2. 重啟 worker。
-
-   ```bash
-   immich-accelerator stop && immich-accelerator start
-   ```
+2. 重啟 worker。以 Homebrew services 管理時使用 `brew services restart immich-accelerator`，否則使用 `immich-accelerator stop && immich-accelerator start`。
 
 3. 於 Immich 執行**重新提取照片元數據**。
 
-若不想記得版本切換這件事，可以用一個包裝腳本取代 `immich-accelerator start`，效果與容器的 `entrypoint` 相同：
+上述步驟可以合併成一個腳本，需要更新時執行一次即可：
 
 ```bash
 #!/bin/bash
-# ~/.local/bin/immich-start
+# ~/.local/bin/immich-geodata-update
 set -e
 bash <(curl -sSL https://github.com/RxChi1d/immich-geodata-zh-tw/releases/latest/download/update_data.sh) --install
-immich-accelerator start
+brew services restart immich-accelerator
 ```
 
 安裝流程本身是冪等的，資料已是最新時重跑不會有副作用。


### PR DESCRIPTION
## 變更說明

在實際的 macOS 分離式部署環境測試 v3.2.0 的安裝流程時，發現 README 的重啟指令在 Homebrew services 管理下會產生競態。

### 問題

環境：MacBook Air M1 / macOS 26.3 / immich-accelerator 1.10.0，由 `brew services` 管理（launchd，`KeepAlive` 開啟）。

README 目前的步驟 3：

```bash
immich-accelerator stop && immich-accelerator start
```

`stop` 之後 launchd 依 `KeepAlive` 立即重啟服務，隨後的 `start` 因連接埠 3003 已被佔用而失敗：

```
[native-ml] cannot listen on port 3003: POSIXErrorCode(rawValue: 48): Address already in use
WARNING   native Swift failed to start
ERROR:    [Errno 48] error while attempting to bind on address ('0.0.0.0', 3003): address already in use
WARNING ML service will not start (no native bundle, no venv).
```

地理資料的更新目的仍會達成（worker 有重啟，匯入照常執行），但 ML 服務的 PID 檔已被 `stop` 移除，導致 `immich-accelerator status` 誤報為 stopped，且錯誤訊息會將使用者導向 `brew reinstall`。

加速器自身的 Homebrew caveats 亦指明升級後應使用 `brew services restart`。

### 變更內容

- 安裝與更新章節在 Homebrew services 情境下改用 `brew services restart immich-accelerator`，並保留非 services 管理的原指令。
- 補充：分離式部署下 Docker 端設定 `IMMICH_WORKERS_INCLUDE=api` 後不會讀取地理資料（`MetadataService` 的 bootstrap 限定 microservices worker），可自 `entrypoint` 移除更新指令，避免每次啟動重複下載 release。
- 安裝步驟一補上先確認路徑的理由：加速器的 server 目錄依 Immich 版本區分，需確認偵測到的版本與執行中的 Immich 相符。

## 變更類型

- [x] 文檔（docs）

## 測試

- [x] 其他（請說明）：於 macOS 分離式部署環境實測。`brew services restart` 後 worker 與 ML 皆被正確追蹤、PID 檔正常寫入；`immich-accelerator status` 顯示兩者 running。本 PR 未變更程式碼。

## 檢查清單

- [x] PR 標題遵循 Conventional Commits 格式
- [x] Commit 訊息遵循專案規範（zh-tw、Google 風格）
- [x] 面向使用者的變更已記錄於 CHANGELOG.md 的 [未發佈版本]
- [x] 相關文檔（README、README.en）已同步更新
- [x] 未包含不應提交的檔案（產物、暫存檔、敏感資訊）