### PR TITLE
docs: 修正新增國家指引對 handler 職責的錯誤描述

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,7 +224,7 @@ src/pipeline/
   - 輸出標準化欄位：latitude, longitude, country, admin_1-4
 
 #### 2. Transform（轉換）
-- `transform_cities_schema`：將標準 CSV 轉成 CITIES_SCHEMA，負責生成
+- `transform_cities_schema`：將 normalized CSV 轉成 cities500 欄位格式，負責生成
   geoname_id、對應行政區與補齊時區、國家代碼。
 
 #### 3. Load（載入）
@@ -253,10 +253,12 @@ cargo run --release -- release \
 ### 擴充新國家
 
 1. 在 `src/pipeline/extract/handlers.rs` 新增或拆分該國 handler。
-2. 實作該國資料來源讀取、座標轉換、行政區欄位對應與 normalized CSV 輸出：
-   - `geoname_id` 從 `92_000_000` 起算。
-   - 填寫正確時區與 `country_code`。
-   - 輸出需符合 `CITIES_SCHEMA`。
+2. 實作該國資料來源讀取、座標轉換與行政區欄位對應，輸出 normalized CSV
+   （欄位為 `latitude,longitude,country,admin_1..admin_4`）。
+   - `geoname_id`、時區與 `country_code` 由 `transform_cities_schema` 填入，
+     不在 handler 產生。
+   - 時區需在 `country_profile` 註冊解析方式（多時區國家另備對照表，
+     例如 `indonesia_timezone::timezone_for_province`）。
 3. 若該國使用 Wikidata 翻譯，遵循 P131 parent 驗證標準：
    - 人工查證該國的 Wikidata QID（以即時查詢確認 label），寫入 handler
      常數並附中文名註解；QID 為 Wikidata 永久識別碼，不做執行期查詢。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ PR 變更到這些檔案時，需加上 `data-update` 標籤以確認這是刻�
 ## 新增支援的國家
 
 1. 在 `src/pipeline/extract/handlers.rs` 新增該國 handler，並同步更新 CLI 的國家解析與 handler routing。
-2. 實作資料來源讀取、座標轉換與行政區欄位對應，輸出符合 `CITIES_SCHEMA` 的 CSV：`geoname_id` 自 `92_000_000` 起算，並填入正確的時區與 `country_code`。
+2. 實作資料來源讀取、座標轉換與行政區欄位對應，輸出欄位為 `latitude,longitude,country,admin_1..admin_4` 的 normalized CSV。`geoname_id`、時區與 `country_code` 不在 handler 產生，由後續的 `transform_cities_schema` 填入；多時區國家需另備省份對照表並在 `country_profile` 註冊。
 3. 若該國使用 Wikidata 翻譯，須遵循 P131 隸屬驗證標準：
    - 人工查證該國的 Wikidata QID 並寫入 handler 常數，附上中文名註解；QID 不做執行期查詢。
    - 建構 `TranslationDataset` 時必填 `country_qid`，逐級驗證 admin2 對 admin1、admin1 對國家的隸屬關係。

--- a/docs/en/contributing.md
+++ b/docs/en/contributing.md
@@ -56,7 +56,7 @@ When a PR changes these files, add the `data-update` label to confirm the data u
 ## Adding Support for a Country
 
 1. Add the country handler in `src/pipeline/extract/handlers.rs`, and update the CLI country parsing and handler routing to match.
-2. Implement the data source reader, coordinate conversion, and administrative division field mapping, and emit a CSV that matches `CITIES_SCHEMA`: `geoname_id` starts at `92_000_000`, with the correct time zone and `country_code`.
+2. Implement the data source reader, coordinate conversion, and administrative division field mapping, and emit a normalized CSV with the columns `latitude,longitude,country,admin_1..admin_4`. The handler does not produce `geoname_id`, the time zone, or `country_code` — `transform_cities_schema` fills those in later. A country spanning several time zones needs a province lookup table registered through `country_profile`.
 3. If the country uses Wikidata translations, follow the P131 containment verification standard:
    - Look up the country's Wikidata QID manually, write it into a handler constant, and annotate it with the Chinese name. QIDs are never queried at runtime.
    - Set `country_qid` when building the `TranslationDataset`, and verify containment level by level: admin2 against admin1, admin1 against the country.


### PR DESCRIPTION
## 問題

更新部落格技術文章時，對照程式碼發現 `CONTRIBUTING.md`、`docs/en/contributing.md` 與 `CLAUDE.md` 的「新增支援的國家」第 2 點有三項與實作不符：

| 文件宣稱 | 實際 |
| :--- | :--- |
| handler 需自 `92_000_000` 起算 `geoname_id` | handler 輸出的 CSV 根本沒有 `geoname_id` 欄。該值由 `transform_cities_schema` 指派，production path 的起始值是 `calculate_global_max_geoname_id() + 1`（`src/cli.rs:233,239`），即現有資料的全域最大值加一。`92_000_000` 只出現在 `fixtures/tw_minimal/manifest.json` 與測試斷言 |
| handler 需填入時區與 `country_code` | 兩者都在 `transform_cities_schema` 填入（`src/pipeline/transform_cities_schema.rs:91,101`）。多時區國家的解析方式在 `country_profile` 註冊，例如 `indonesia_timezone::timezone_for_province` |
| 輸出需符合 `CITIES_SCHEMA` | 這個識別符在程式碼中不存在，全 repo 只出現在文件裡 |

handler 實際輸出的 normalized CSV 欄位是 `latitude,longitude,country,admin_1..admin_4`（可由任一 `meta_data/*_geodata.csv` 的表頭確認）。

照現行指引實作新國家會產出多餘欄位，並選錯 ID 區段。

## 解法

改為描述實際的職責邊界：handler 只負責讀取來源、座標轉換與行政區欄位對應；`geoname_id`、時區與國碼由後續階段填入。同時把 `CLAUDE.md` 架構說明中「轉成 CITIES_SCHEMA」改為「轉成 cities500 欄位格式」。

## 驗證

- `grep -rn 'CITIES_SCHEMA' --include='*.rs'` 無任何命中，確認該識別符不存在。
- `grep -rn '92_000_000'` 的命中僅在 `fixtures/`、`tests/polars_table.rs` 與 `src/pipeline/fixtures.rs:180` 的斷言，無 production 程式碼。
- `head -1 meta_data/id_geodata.csv` 確認欄位為 `latitude,longitude,country,admin_1,admin_2,admin_3,admin_4`。
- `cargo fmt --check` 與 `cargo test`（155 項）通過。

## 影響範圍

- [ ] 改變安裝或操作方式
- [ ] 改變輸出的地理資料
- [ ] 使用者需重新擷取照片中繼資料才會生效
- [ ] 包含破壞性變更（請說明影響與遷移方式）

## 發布說明

```release-note
NONE
```