### PR TITLE
chore(docs): 修正 handler 國家清單漂移

### DIFF
--- a/.agents/skills/immich-geodata-source-release/SKILL.md
+++ b/.agents/skills/immich-geodata-source-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: immich-geodata-source-release
-description: 當需要更新 immich-geodata-zh-tw 原始邊界資料、下載最新 TW/JP/KR/TH 圖資、驗證 Shapefile/GeoJSON schema、執行 Rust extract/release pipeline，或驗證 release artifacts 時使用。
+description: 當需要更新 immich-geodata-zh-tw 原始邊界資料、下載最新 TW/JP/KR/TH/ID 圖資、驗證 Shapefile/GeoJSON schema、執行 Rust extract/release pipeline，或驗證 release artifacts 時使用。
 version: 1.0.0
 license: MIT
 ---
@@ -24,13 +24,19 @@ license: MIT
 git status --short --branch
 ```
 
-2. 若需要更新 upstream TW/JP/KR/TH 原始圖資，從官方來源下載完整資料：
+2. 若需要更新 upstream 原始圖資，從官方來源下載完整資料：
    - TW：NLSC 村(里)界（TWD97 經緯度）Shapefile。
    - JP：MLIT N03 全國行政區 Shapefile。
    - KR：admdongkor `HangJeongDong_ver*.geojson`。
    - TH：HDX Thailand COD-AB（https://data.humdata.org/dataset/cod-ab-tha）
      `tha_admin_boundaries.shp.zip`，解壓縮後使用 `tha_admin3.shp`。
-3. extract 前先驗證新來源檔 schema。必要輸入是完整 TW NLSC 村里界 Shapefile、完整 JP MLIT N03 全國 Shapefile、完整 KR `HangJeongDong_ver*.geojson`、完整 TH COD-AB `tha_admin3.shp`（需含 `adm1_name`、`adm1_name1`、`adm2_name`、`adm2_name1`、`adm3_name`、`adm3_name1` 欄位）。
+   - ID：BIG（印尼地理空間資訊局）REST API 分頁下載，端點為
+     `https://geoservices.big.go.id/arcgis/rest/services/BATASWILAYAH/Administrasi_AR_KelDesa_10K/FeatureServer/0/query`，
+     參數 `geometryPrecision=6`、`f=geojson`、`outFields=*`，以 `resultOffset`
+     分頁取回全量 feature。下載後過濾掉 `WADMKD`（desa/村里名）為空白或僅含
+     空格的 feature。必要欄位：`WADMPR`（省）、`WADMKK`（縣/市）、`WADMKC`（鄉鎮）、
+     `WADMKD`（村里）。
+3. extract 前先驗證新來源檔 schema。必要輸入是完整 TW NLSC 村里界 Shapefile、完整 JP MLIT N03 全國 Shapefile、完整 KR `HangJeongDong_ver*.geojson`、完整 TH COD-AB `tha_admin3.shp`（需含 `adm1_name`、`adm1_name1`、`adm2_name`、`adm2_name1`、`adm3_name`、`adm3_name1` 欄位）、完整 ID desa GeoJSON（需含 `WADMPR`、`WADMKK`、`WADMKC`、`WADMKD` 欄位）。
 4. 使用 Rust CLI 執行 extract，例如：
 
 ```bash
@@ -39,7 +45,7 @@ cargo run --release -- extract --country TW \
   --output data/handler/tw_geodata.csv
 ```
 
-5. 使用 Rust CLI 產生 release artifacts。若只更新 handler countries（TW/JP/KR/TH），跳過 LocationIQ：
+5. 使用 Rust CLI 產生 release artifacts。若只更新 handler countries，跳過 LocationIQ：
 
 ```bash
 cargo run --release -- release \

--- a/.agents/skills/immich-geodata-source-release/agents/openai.yaml
+++ b/.agents/skills/immich-geodata-source-release/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Immich Geodata 圖資更新"
-  short_description: "更新 TW/JP/KR/TH 圖資與 release artifacts"
-  default_prompt: "使用 $immich-geodata-source-release 更新 TW/JP/KR/TH 原始圖資，執行 Rust production extract/release pipeline，並驗證產物。"
+  short_description: "更新 TW/JP/KR/TH/ID 圖資與 release artifacts"
+  default_prompt: "使用 $immich-geodata-source-release 更新 TW/JP/KR/TH/ID 原始圖資，執行 Rust production extract/release pipeline，並驗證產物。"
 
 policy:
   allow_implicit_invocation: true

--- a/.claude/skills/immich-geodata-source-release/SKILL.md
+++ b/.claude/skills/immich-geodata-source-release/SKILL.md
@@ -24,7 +24,7 @@ license: MIT
 git status --short --branch
 ```
 
-2. 若需要更新 upstream TW/JP/KR/TH/ID 原始圖資，從官方來源下載完整資料：
+2. 若需要更新 upstream 原始圖資，從官方來源下載完整資料：
    - TW：NLSC 村(里)界（TWD97 經緯度）Shapefile。
    - JP：MLIT N03 全國行政區 Shapefile。
    - KR：admdongkor `HangJeongDong_ver*.geojson`。
@@ -45,7 +45,7 @@ cargo run --release -- extract --country TW \
   --output data/handler/tw_geodata.csv
 ```
 
-5. 使用 Rust CLI 產生 release artifacts。若只更新 handler countries（TW/JP/KR/TH），跳過 LocationIQ：
+5. 使用 Rust CLI 產生 release artifacts。若只更新 handler countries，跳過 LocationIQ：
 
 ```bash
 cargo run --release -- release \

--- a/.github/workflows/validate-rust-release.yaml
+++ b/.github/workflows/validate-rust-release.yaml
@@ -14,7 +14,7 @@ on:
         type: boolean
         default: true
       country_codes:
-        description: 'GeoNames extra data 國家代碼；有 handler 的國家（TW/JP/KR/TH）不需要列入'
+        description: 'GeoNames extra data 國家代碼（ISO 3166-1 alpha-2，多國以空白分隔）；有 handler 的國家不需要列入'
         required: false
         type: string
         default: ''
@@ -97,7 +97,7 @@ jobs:
             args+=(--pass-locationiq)
           fi
 
-          # handler 國家（TW/JP/KR/TH）由 data/handler/*_geodata.csv 自動帶入，
+          # handler 國家由 data/handler/*_geodata.csv 自動帶入，
           # 只有 non-handler 國家需要透過 --country-code 指定。
           read -r -a countries <<< "${COUNTRY_CODES}"
           if [[ "${#countries[@]}" -gt 0 ]]; then


### PR DESCRIPTION
## 問題

`Country::ALL`（`src/pipeline/extract/types.rs:317`）是「哪些國家有 handler」的單一事實來源，該處註解寫得很明白：

> 這是「哪些國家有 handler」的單一事實來源；CLI 的 handler 國家清單由此導出，新增國家時不需（也不能）另行同步。

但多處文字仍重複列舉同一份清單。印尼加入後這些位置沒有跟著更新，全部停留在 `TW/JP/KR/TH`。

## 解法：依用途分別處理，不是一律補上 ID

### 當作文件閱讀的事實清單 → 移除列舉

workflow 輸入說明與 skill 操作步驟。讀者不需知道具體是哪幾國即可理解語意，補成五國只會讓下次新增國家時重演漏更。移除後不再有需要同步的第二份清單。

```diff
- description: 'GeoNames extra data 國家代碼；有 handler 的國家（TW/JP/KR/TH）不需要列入'
+ description: 'GeoNames extra data 國家代碼（ISO 3166-1 alpha-2，多國以空白分隔）；有 handler 的國家不需要列入'
```

### 供比對器匹配的關鍵字 → 補上 ID

skill 的 frontmatter `description` 與 `openai.yaml` 的 `short_description` / `default_prompt`。這些靠具體詞取得匹配力——使用者說「更新印尼圖資」，缺 ID 就少一個明確訊號——抽象化會削弱其存在目的。

兩者失效後果也不同：文件列舉過期會讓讀者依錯誤資訊行動；關鍵字過期只是少觸發一次。

`.claude` 版 frontmatter 早已含 ID，此處補的是 `.agents` 副本的漂移。

## 一併修正審查發現的兩項既有問題

### 1. `.agents` 版 release skill 落後 `.claude` 版一整段

缺印尼的 BIG REST API 下載來源（7 行）與 desa GeoJSON 的必要欄位。

單純移除列舉而不補這段會**製造新問題**：泛稱的「upstream 原始圖資」宣稱涵蓋全部 handler，實際內容卻只有四國。已同步，兩份現在只差 `CLAUDE.md`／`AGENTS.md` 這項平台性差異。

### 2. `country_codes` 輸入未說明格式

實作以 `read -r -a` 切分，逗號分隔的 `GB,US` 會被當成**單一錯誤國碼**。而且只有 handler 國碼會被 `is_handler_country()` 過濾，未知國碼不會——會一路進到 prepare／enhance。因此補上「ISO 3166-1 alpha-2，多國以空白分隔」。

## 刻意未更動

| 對象 | 原因 |
| :--- | :--- |
| `.claude/skills/immich-geodata-country-handler/SKILL.md:10` | 該文實際只涵蓋 TW/JP/KR/TH 的實作經驗，**零處**提及印尼，原敘述準確。一度改為「既有各國」，但那是過度宣稱，已還原 |
| `docs/research/chinese-translation-sources.md:127,192` | 明載為 2026-06 研究紀錄，且已說明清單由 extract handler 單一來源決定 |

## 驗證

純文件變更，無程式碼、無行為影響。

- `validate-rust-release.yaml`、三份 SKILL.md frontmatter、`openai.yaml` 皆以 `yaml.safe_load` 確認可解析
- 兩份 release skill 逐行 diff，確認只剩 `CLAUDE.md`／`AGENTS.md` 的平台性差異
- 全 repo 掃描確認 `TW/JP/KR/TH`（不含 `/ID`）的殘留只剩上表刻意保留的三處
- CI：`Rust gates`、`Diff guards`、`Detect Rust changes`、`PR title`、`autolabeler` 全 pass；`gates` 因無 Rust 變更由 path filter 正常跳過

## 影響範圍

- [ ] 改變安裝或操作方式
- [ ] 改變輸出的地理資料
- [ ] 使用者需重新擷取照片中繼資料才會生效
- [ ] 包含破壞性變更（請說明影響與遷移方式）

## 發布說明

```release-note
NONE
```